### PR TITLE
feat: health + graph_delete — diagnose and execute refactors (v0.10.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "yoyo"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoyo"
-version = "0.9.3"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]

--- a/src/engine/analysis.rs
+++ b/src/engine/analysis.rs
@@ -1,11 +1,15 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
 
-use super::types::{DocMatch, FindDocsPayload};
-use super::util::{load_bake_index, resolve_project_root};
+use super::types::{
+    DeadFunction, DocMatch, DuplicateEntry, DuplicateGroup, FindDocsPayload, GodFunction,
+    GraphDeletePayload, HealthPayload,
+};
+use super::util::{load_bake_index, reindex_files, resolve_project_root};
+
 
 /// Public entrypoint for the `blast_radius` tool.
 pub fn blast_radius(path: Option<String>, symbol: String, depth: Option<usize>) -> Result<String> {
@@ -145,4 +149,179 @@ pub fn find_docs(path: Option<String>, doc_type: String, limit: Option<usize>) -
 
     let json = serde_json::to_string_pretty(&payload)?;
     Ok(json)
+}
+
+
+// ── health ────────────────────────────────────────────────────────────────────
+
+/// Diagnose a codebase: dead code, god functions, duplicate hints.
+pub fn health(path: Option<String>, top: Option<usize>) -> Result<String> {
+    let root = resolve_project_root(path)?;
+    let bake = load_bake_index(&root)?
+        .ok_or_else(|| anyhow::anyhow!("No bake index found. Run `bake` first."))?;
+
+    let top_n = top.unwrap_or(10);
+
+    // Set of every callee name ever called (lowercased).
+    let all_callees: HashSet<String> = bake
+        .functions
+        .iter()
+        .flat_map(|f| f.calls.iter().map(|c| c.callee.to_lowercase()))
+        .collect();
+
+    // Dead code: indexed but never called; skip main, tests, very short names.
+    let mut dead_code: Vec<DeadFunction> = bake
+        .functions
+        .iter()
+        .filter(|f| {
+            let lc = f.name.to_lowercase();
+            !all_callees.contains(&lc)
+                && lc != "main"
+                && !lc.starts_with("test")
+                && !lc.ends_with("_test")
+                && !f.file.contains("test")
+                && f.name.len() > 2
+        })
+        .map(|f| DeadFunction {
+            name: f.name.clone(),
+            file: f.file.clone(),
+            start_line: f.start_line,
+            end_line: f.end_line,
+            lines: f.end_line.saturating_sub(f.start_line) + 1,
+        })
+        .collect();
+    dead_code.sort_by(|a, b| b.lines.cmp(&a.lines));
+
+    // God functions: ranked by complexity × unique fan-out.
+    let mut god_functions: Vec<GodFunction> = bake
+        .functions
+        .iter()
+        .map(|f| {
+            let fan_out = f.calls.iter().map(|c| c.callee.as_str()).collect::<HashSet<_>>().len();
+            let score = f.complexity.saturating_mul(fan_out as u32);
+            GodFunction {
+                name: f.name.clone(),
+                file: f.file.clone(),
+                start_line: f.start_line,
+                complexity: f.complexity,
+                fan_out,
+                score,
+            }
+        })
+        .filter(|g| g.score > 0)
+        .collect();
+    god_functions.sort_by(|a, b| b.score.cmp(&a.score));
+    god_functions.truncate(top_n);
+
+    // Duplicate hints: group by stem (name with common verb prefix stripped).
+    const PREFIXES: &[&str] = &[
+        "get_", "set_", "create_", "update_", "delete_", "handle_", "run_",
+        "fetch_", "load_", "save_", "parse_", "build_", "make_", "init_",
+        "process_", "validate_", "check_",
+    ];
+    let stem = |name: &str| -> String {
+        let lc = name.to_lowercase();
+        for p in PREFIXES {
+            if lc.starts_with(p) {
+                return lc[p.len()..].to_string();
+            }
+        }
+        lc
+    };
+
+    let mut by_stem: HashMap<String, Vec<&crate::lang::IndexedFunction>> = HashMap::new();
+    for f in &bake.functions {
+        let s = stem(&f.name);
+        if s.len() > 2 {
+            by_stem.entry(s).or_default().push(f);
+        }
+    }
+
+    let mut duplicate_hints: Vec<DuplicateGroup> = by_stem
+        .into_iter()
+        .filter(|(_, funcs)| {
+            funcs.len() >= 2
+                && funcs.iter().map(|f| f.file.as_str()).collect::<HashSet<_>>().len() >= 2
+        })
+        .map(|(s, funcs)| DuplicateGroup {
+            stem: s,
+            functions: funcs
+                .iter()
+                .map(|f| DuplicateEntry {
+                    name: f.name.clone(),
+                    file: f.file.clone(),
+                    start_line: f.start_line,
+                })
+                .collect(),
+        })
+        .collect();
+    duplicate_hints.sort_by(|a, b| a.stem.cmp(&b.stem));
+    duplicate_hints.truncate(top_n);
+
+    let payload = HealthPayload {
+        tool: "health",
+        version: env!("CARGO_PKG_VERSION"),
+        project_root: root,
+        dead_code,
+        god_functions,
+        duplicate_hints,
+    };
+    Ok(serde_json::to_string_pretty(&payload)?)
+}
+
+// ── graph_delete ──────────────────────────────────────────────────────────────
+
+/// Remove a function from a file by name. Requires a prior bake.
+pub fn graph_delete(path: Option<String>, name: String, file: Option<String>) -> Result<String> {
+    let root = resolve_project_root(path)?;
+    let bake = load_bake_index(&root)?
+        .ok_or_else(|| anyhow::anyhow!("No bake index. Run `bake` first."))?;
+
+    let name_lc = name.to_lowercase();
+    let file_lc = file.as_deref().map(|s| s.to_lowercase());
+
+    let func = bake
+        .functions
+        .iter()
+        .find(|f| {
+            f.name.to_lowercase() == name_lc
+                && file_lc
+                    .as_deref()
+                    .map(|ff| f.file.to_lowercase().ends_with(ff))
+                    .unwrap_or(true)
+        })
+        .ok_or_else(|| anyhow::anyhow!("Symbol {:?} not found in bake index.", name))?;
+
+    let rel_file = func.file.clone();
+    let byte_start = func.byte_start;
+    let byte_end = func.byte_end;
+
+    let full_path = root.join(&rel_file);
+    let mut bytes = std::fs::read(&full_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", rel_file, e))?;
+
+    if byte_end > bytes.len() || byte_start > byte_end {
+        return Err(anyhow::anyhow!(
+            "Invalid byte range [{}, {}) for {} (file len {})",
+            byte_start, byte_end, rel_file, bytes.len()
+        ));
+    }
+
+    let bytes_removed = byte_end - byte_start;
+    bytes.drain(byte_start..byte_end);
+
+    std::fs::write(&full_path, &bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", rel_file, e))?;
+
+    let _ = reindex_files(&root, &[rel_file.as_str()]);
+
+    let payload = GraphDeletePayload {
+        tool: "graph_delete",
+        version: env!("CARGO_PKG_VERSION"),
+        project_root: root,
+        name,
+        file: rel_file,
+        bytes_removed,
+    };
+    Ok(serde_json::to_string_pretty(&payload)?)
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -8,7 +8,7 @@ mod search;
 pub(crate) mod types;
 mod util;
 
-pub use analysis::{blast_radius, find_docs};
+pub use analysis::{blast_radius, find_docs, graph_delete, health};
 pub use api::{all_endpoints, api_surface, api_trace, crud_operations};
 pub use edit::{multi_patch, patch, patch_bytes, patch_by_symbol, slice, PatchEdit};
 pub use graph::{graph_add, graph_move, graph_rename, trace_down};

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -415,3 +415,59 @@ pub(crate) struct TraceDownPayload {
     pub(crate) chain: Vec<TraceNode>,
     pub(crate) unresolved: Vec<String>,
 }
+
+// ── health ────────────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub(crate) struct HealthPayload {
+    pub(crate) tool: &'static str,
+    pub(crate) version: &'static str,
+    pub(crate) project_root: PathBuf,
+    pub(crate) dead_code: Vec<DeadFunction>,
+    pub(crate) god_functions: Vec<GodFunction>,
+    pub(crate) duplicate_hints: Vec<DuplicateGroup>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DeadFunction {
+    pub(crate) name: String,
+    pub(crate) file: String,
+    pub(crate) start_line: u32,
+    pub(crate) end_line: u32,
+    pub(crate) lines: u32,
+}
+
+#[derive(Serialize)]
+pub(crate) struct GodFunction {
+    pub(crate) name: String,
+    pub(crate) file: String,
+    pub(crate) start_line: u32,
+    pub(crate) complexity: u32,
+    pub(crate) fan_out: usize,
+    pub(crate) score: u32,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DuplicateGroup {
+    pub(crate) stem: String,
+    pub(crate) functions: Vec<DuplicateEntry>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DuplicateEntry {
+    pub(crate) name: String,
+    pub(crate) file: String,
+    pub(crate) start_line: u32,
+}
+
+// ── graph_delete ──────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub(crate) struct GraphDeletePayload {
+    pub(crate) tool: &'static str,
+    pub(crate) version: &'static str,
+    pub(crate) project_root: PathBuf,
+    pub(crate) name: String,
+    pub(crate) file: String,
+    pub(crate) bytes_removed: usize,
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -315,6 +315,15 @@ fn list_tools() -> Value {
             "depth": i("Maximum call depth to follow (default 5)"),
             "file": s("Optional file path substring to disambiguate when multiple functions share the same name")
         })),
+        tool("health", "Diagnose codebase health: dead code (never-called functions), god functions (high complexity × fan-out), and duplicate hints (same-stem functions across different files). Run after bake.", json!({
+            "path": p(),
+            "top": i("Max results per category (default 10)")
+        })),
+        tool_req("graph_delete", "Remove a function from a file by name. Erases its byte range and reindexes. Use health or blast_radius to confirm it is safe to delete.", &["name"], json!({
+            "path": p(),
+            "name": s("Exact function name to delete (matched case-insensitively in bake index)"),
+            "file": s("Optional file path substring to disambiguate when multiple functions share the same name")
+        })),
     ]})
 }
 
@@ -463,6 +472,10 @@ async fn call_tool(params: Value) -> Result<Value> {
         )?),
         "trace_down" => ok_text(crate::engine::trace_down(
             path, a.str_req("name", "trace_down")?, a.uint_opt("depth"), a.str_opt("file"),
+        )?),
+        "health" => ok_text(crate::engine::health(path, a.uint_opt("top"))?),
+        "graph_delete" => ok_text(crate::engine::graph_delete(
+            path, a.str_req("name", "graph_delete")?, a.str_opt("file"),
         )?),
         other => Err(anyhow::anyhow!("Unknown tool: {other}")),
     }


### PR DESCRIPTION
## What

Two new tools that close the refactor loop.

### `health` — codebase diagnosis

Run it on any project after `bake` to get a prioritised hit list:

| Category | Signal |
|---|---|
| `dead_code` | Functions never called anywhere — sorted by size |
| `god_functions` | Ranked by `complexity × fan_out` score |
| `duplicate_hints` | Same-stem functions across different files |

### `graph_delete` — remove a function

The missing inverse of `graph_add`. Resolves by name from the bake index, erases the byte range, writes the file, reindexes automatically.

## The full refactor workflow

```
health          → find what's wrong
blast_radius    → assess risk before touching anything
graph_delete    → remove dead code
graph_add       → scaffold replacements for god functions
patch_by_symbol → fill them in
graph_rename    → fix all call sites
graph_move      → relocate misplaced functions
```

## Test results on yoyo itself

- Dead code: `extensions()` in all 4 lang analyzers (trait method marked `#[allow(dead_code)]`) ✓
- God functions: `architecture_map` (score 504), `supersearch` (450), `walk_ts` (440) ✓  
- Duplicate hints: engine/CLI pairs (`bake`/`run_bake`, etc.) and per-lang implementations (`analyze_file`, `collect_calls`) ✓

Closes #26 (execution side of the refactor loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)