### PR TITLE
perf: parallel bake + supersearch via rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -428,6 +479,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
+ "rayon",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.49", features = ["rt-multi-thread", "io-util", "io-std", "macros"] }
+rayon = "1.10"
 tree-sitter = "0.26.6"
 tree-sitter-go = "0.25.0"
 tree-sitter-python = "0.25.0"

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -119,6 +119,8 @@ pub fn supersearch(
     file_filter: Option<String>,
     limit: Option<usize>,
 ) -> Result<String> {
+    use rayon::prelude::*;
+
     let root = resolve_project_root(path)?;
     let bake = load_bake_index(&root)?
         .ok_or_else(|| anyhow!("No bake index found. Run `bake` first to build bakes/latest/bake.json."))?;
@@ -127,7 +129,6 @@ pub fn supersearch(
     let q = query.to_lowercase();
     let ff = file_filter.as_deref().map(str::to_lowercase);
 
-    // Normalize context/pattern to known values; fall back to "all" if unknown.
     let context_norm = match context.as_str() {
         "all" | "strings" | "comments" | "identifiers" => context.clone(),
         _ => "all".to_string(),
@@ -137,69 +138,67 @@ pub fn supersearch(
         _ => "all".to_string(),
     };
 
-    let mut matches = Vec::new();
-
-    // Cache analyzers by language to avoid reallocating all 4 boxed analyzers per file.
-    let mut analyzer_cache: std::collections::HashMap<&str, Option<Box<dyn crate::lang::LanguageAnalyzer>>> =
-        std::collections::HashMap::new();
-
-    for file in &bake.files {
-        let lang = file.language.as_str();
-        if !matches!(lang, "typescript" | "javascript" | "rust" | "python" | "go") {
-            continue;
-        }
-
-        let path_str = file.path.to_string_lossy();
-        if exclude_tests && (path_str.contains("test") || path_str.contains("spec")) {
-            continue;
-        }
-        if let Some(ref f) = ff {
-            if !path_str.to_lowercase().contains(f.as_str()) {
-                continue;
+    let mut matches: Vec<SupersearchMatch> = bake
+        .files
+        .par_iter()
+        .filter(|file| {
+            let lang = file.language.as_str();
+            if !matches!(lang, "typescript" | "javascript" | "rust" | "python" | "go") {
+                return false;
             }
-        }
-
-        let full_path = root.join(&file.path);
-        let content = match fs::read_to_string(&full_path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        let file_rel = file.path.to_string_lossy().into_owned();
-
-        let mut used_ast = false;
-        let analyzer = analyzer_cache
-            .entry(lang)
-            .or_insert_with(|| crate::lang::find_analyzer(lang));
-        if let Some(analyzer) = analyzer {
-            if analyzer.supports_ast_search() {
-                let mut file_matches =
-                    analyzer.ast_search(&content, &q, &context_norm, &pattern_norm);
-                // Deduplicate by line — the AST walk can emit multiple nodes per line.
-                file_matches.sort_by_key(|m| m.line);
-                file_matches.dedup_by_key(|m| m.line);
-                for m in file_matches {
-                    matches.push(SupersearchMatch {
-                        file: file_rel.clone(),
-                        line: m.line,
-                        snippet: m.snippet,
-                    });
-                }
-                used_ast = true;
+            let path_str = file.path.to_string_lossy();
+            if exclude_tests && (path_str.contains("test") || path_str.contains("spec")) {
+                return false;
             }
-        }
-        if !used_ast {
-            // Fallback: line-oriented text search for unsupported languages (html, yaml, etc.).
-            for (idx, line) in content.lines().enumerate() {
-                if line.to_lowercase().contains(&q) {
-                    matches.push(SupersearchMatch {
-                        file: file_rel.clone(),
-                        line: (idx + 1) as u32,
-                        snippet: line.trim().to_string(),
-                    });
+            if let Some(ref f) = ff {
+                if !path_str.to_lowercase().contains(f.as_str()) {
+                    return false;
                 }
             }
-        }
-    }
+            true
+        })
+        .flat_map(|file| {
+            let lang = file.language.as_str();
+            let full_path = root.join(&file.path);
+            let content = match fs::read_to_string(&full_path) {
+                Ok(c) => c,
+                Err(_) => return vec![],
+            };
+            let file_rel = file.path.to_string_lossy().into_owned();
+            let mut file_matches = Vec::new();
+
+            let analyzer = crate::lang::find_analyzer(lang);
+            let mut used_ast = false;
+            if let Some(analyzer) = analyzer {
+                if analyzer.supports_ast_search() {
+                    let mut ast_matches =
+                        analyzer.ast_search(&content, &q, &context_norm, &pattern_norm);
+                    ast_matches.sort_by_key(|m| m.line);
+                    ast_matches.dedup_by_key(|m| m.line);
+                    for m in ast_matches {
+                        file_matches.push(SupersearchMatch {
+                            file: file_rel.clone(),
+                            line: m.line,
+                            snippet: m.snippet,
+                        });
+                    }
+                    used_ast = true;
+                }
+            }
+            if !used_ast {
+                for (idx, line) in content.lines().enumerate() {
+                    if line.to_lowercase().contains(&q) {
+                        file_matches.push(SupersearchMatch {
+                            file: file_rel.clone(),
+                            line: (idx + 1) as u32,
+                            snippet: line.trim().to_string(),
+                        });
+                    }
+                }
+            }
+            file_matches
+        })
+        .collect();
 
     matches.truncate(limit.unwrap_or(200));
 
@@ -214,8 +213,7 @@ pub fn supersearch(
         matches,
     };
 
-    let json = serde_json::to_string_pretty(&payload)?;
-    Ok(json)
+    Ok(serde_json::to_string_pretty(&payload)?)
 }
 
 /// Public entrypoint for the `file_functions` tool: per-file function overview.

--- a/src/engine/util.rs
+++ b/src/engine/util.rs
@@ -110,20 +110,17 @@ fn parse_semver(v: &str) -> (u32, u32, u32) {
 }
 
 pub(crate) fn build_bake_index(root: &PathBuf) -> Result<BakeIndex> {
+    use rayon::prelude::*;
+
+    // Phase 1: collect file metadata (sequential directory walk — fast).
     let mut languages = BTreeSet::new();
-    let mut files = Vec::new();
-    let mut functions = Vec::new();
-    let mut endpoints = Vec::new();
-    let mut types = Vec::new();
+    let mut files: Vec<BakeFile> = Vec::new();
 
     fn walk(
         dir: &Path,
         root: &Path,
         languages: &mut BTreeSet<String>,
         files: &mut Vec<BakeFile>,
-        functions: &mut Vec<crate::lang::IndexedFunction>,
-        endpoints: &mut Vec<crate::lang::IndexedEndpoint>,
-        types: &mut Vec<crate::lang::IndexedType>,
     ) -> Result<()> {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
@@ -137,7 +134,7 @@ pub(crate) fn build_bake_index(root: &PathBuf) -> Result<BakeIndex> {
                         continue;
                     }
                 }
-                walk(&path, root, languages, files, functions, endpoints, types)?;
+                walk(&path, root, languages, files)?;
             } else if path.is_file() {
                 let meta = entry.metadata()?;
                 let bytes = meta.len();
@@ -151,31 +148,32 @@ pub(crate) fn build_bake_index(root: &PathBuf) -> Result<BakeIndex> {
                     language: lang.to_string(),
                     bytes,
                 });
-
-                if let Some(analyzer) = crate::lang::find_analyzer(lang) {
-                    match analyzer.analyze_file(root, &path) {
-                        Ok((funcs, eps, typs)) => {
-                            functions.extend(funcs);
-                            endpoints.extend(eps);
-                            types.extend(typs);
-                        }
-                        Err(_) => {} // skip files that fail to parse
-                    }
-                }
             }
         }
         Ok(())
     }
 
-    walk(
-        root.as_path(),
-        root.as_path(),
-        &mut languages,
-        &mut files,
-        &mut functions,
-        &mut endpoints,
-        &mut types,
-    )?;
+    walk(root.as_path(), root.as_path(), &mut languages, &mut files)?;
+
+    // Phase 2: parse files in parallel (CPU-bound tree-sitter work).
+    let results: Vec<_> = files
+        .par_iter()
+        .filter_map(|file| {
+            let lang = file.language.as_str();
+            let analyzer = crate::lang::find_analyzer(lang)?;
+            let full_path = root.join(&file.path);
+            analyzer.analyze_file(root, &full_path).ok()
+        })
+        .collect();
+
+    let mut functions = Vec::new();
+    let mut endpoints = Vec::new();
+    let mut types = Vec::new();
+    for (funcs, eps, typs) in results {
+        functions.extend(funcs);
+        endpoints.extend(eps);
+        types.extend(typs);
+    }
 
     Ok(BakeIndex {
         version: env!("CARGO_PKG_VERSION").to_string(),


### PR DESCRIPTION
## What

Adds `rayon` and parallelizes the two hottest read paths.

### `build_bake_index`
- Phase 1: sequential directory walk to collect file metadata (fast — just `readdir`)
- Phase 2: `par_iter()` over collected files for `analyze_file` (tree-sitter parsing is CPU-bound — now runs on all cores simultaneously)

### `supersearch`
- `par_iter()` + `flat_map` over `bake.files`
- Each file is read from disk and AST-searched independently
- No shared mutable state — no locks needed

## Why this is safe
`LanguageAnalyzer` already requires `Send + Sync`. Each file is processed independently with no shared writes. Rayon's work-stealing scheduler handles load balancing automatically.

## Expected impact
On a 10-core M-series Mac: **5-10x speedup** on large codebases for both `bake` and `supersearch`. Small projects (like yoyo itself) won't show much difference — the gains scale with codebase size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)