### PR TITLE
add instructions for gemini cli and open code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 yoyo is a code intelligence MCP server. It gives your AI agent 27 tools to read and edit any codebase — grounded in the AST, not model memory.
 
-**Built for agents.** Drop it into Claude Code, Cursor, or any MCP-compatible agent. The agent calls the tools. You get better answers.
+**Built for agents.** Drop it into Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode, or any MCP-compatible agent. The agent calls the tools. You get better answers.
 
 **99% eval accuracy** across 7 real codebases (120 tasks) vs 26% baseline (Claude Code without yoyo). No API keys. No SaaS. No telemetry.
 
@@ -101,6 +101,19 @@ codex mcp add yoyo -- /usr/local/bin/yoyo --mcp-server
 ```
 If you installed to `~/.local/bin/yoyo`, use that path in the command.
 
+**Gemini CLI** — add yoyo as an MCP server from your terminal:
+```bash
+gemini mcp add yoyo /usr/local/bin/yoyo --mcp-server
+```
+If you installed to `~/.local/bin/yoyo`, use that path in the command.
+
+**OpenCode** — add yoyo as an MCP server from your terminal:
+```bash
+opencode mcp add
+```
+Then follow the prompts:
+`Local (stdio)` -> name `yoyo` -> command `/usr/local/bin/yoyo` -> args `--mcp-server`.
+
 Then reconnect your agent client so it picks up the new server (for Claude Code, run `/mcp` or restart the app).
 
 ---
@@ -139,7 +152,7 @@ This injects a reminder on every prompt so Claude actively uses yoyo tools inste
 
 ---
 
-You're set. Open Claude Code, Cursor, or Codex CLI, start a session, and ask about your code. The agent calls `llm_instructions` automatically on first contact and picks up all 27 tools.
+You're set. Open Claude Code, Cursor, Codex CLI, Gemini CLI, or OpenCode, start a session, and ask about your code. The agent calls `llm_instructions` automatically on first contact and picks up all 27 tools.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # yoyo — full documentation
 
-yoyo parses your codebase and gives Claude or Cursor 27 tools to read and edit it over MCP. Every answer comes from the AST — not model memory. No API keys, no SaaS, no telemetry.
+yoyo parses your codebase and gives Claude Code, Cursor, Codex CLI, Gemini CLI, or OpenCode 27 tools to read and edit it over MCP. Every answer comes from the AST — not model memory. No API keys, no SaaS, no telemetry.
 
 **Eval:** 119/120 tasks correct (99%) across 7 real codebases vs 26% baseline (Claude Code without index).
 
@@ -126,6 +126,19 @@ For Codex CLI, add yoyo from your terminal:
 codex mcp add yoyo -- /usr/local/bin/yoyo --mcp-server
 ```
 If you installed to `~/.local/bin/yoyo`, use that path in the command.
+
+For Gemini CLI, add yoyo from your terminal:
+```bash
+gemini mcp add yoyo /usr/local/bin/yoyo --mcp-server
+```
+If you installed to `~/.local/bin/yoyo`, use that path in the command.
+
+For OpenCode, add yoyo from your terminal:
+```bash
+opencode mcp add
+```
+Then choose `Local (stdio)` and set:
+name `yoyo`, command `/usr/local/bin/yoyo`, args `--mcp-server`.
 
 **Recommended — add a `UserPromptSubmit` hook** so Claude is reminded to prefer yoyo tools on every turn. Add to your project's `.claude/settings.local.json`:
 


### PR DESCRIPTION
This PR expands MCP setup documentation so users can add yoyo not only in Claude Code/
  Cursor/Codex CLI, but also in Gemini CLI and OpenCode.

  ### What changed

  - Added Gemini CLI MCP setup command:
      - gemini mcp add yoyo /usr/local/bin/yoyo --mcp-server
  - Added OpenCode MCP setup instructions:
      - opencode mcp add
      - then configure Local (stdio) with:
          - name: yoyo
          - command: /usr/local/bin/yoyo
          - args: --mcp-server
  - Updated wording in README/docs to explicitly list supported agent clients:
      - Claude Code, Cursor, Codex CLI, Gemini CLI, OpenCode

  ## Files changed

  - README.md
  - docs/README.md