### PR TITLE
Add scoped monorepo bake metadata and invalidation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -312,6 +312,22 @@ pub struct RoutesArgs {
     /// Optional path to the project directory to analyze.
     #[arg(long)]
     pub path: Option<String>,
+
+    /// Optional path or handler substring to narrow endpoint results.
+    #[arg(long)]
+    pub query: Option<String>,
+
+    /// Optional HTTP method filter.
+    #[arg(long)]
+    pub method: Option<String>,
+
+    /// Optional workspace/package/slice hint for monorepos, e.g. backend or web.
+    #[arg(long)]
+    pub scope: Option<String>,
+
+    /// Maximum number of endpoints to return.
+    #[arg(long)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Args, Debug)]
@@ -339,6 +355,10 @@ pub struct ImpactArgs {
     /// Include handler source inline in endpoint mode.
     #[arg(long, default_value_t = false)]
     pub include_source: bool,
+
+    /// Optional workspace/package/slice hint for monorepos, e.g. backend or web.
+    #[arg(long)]
+    pub scope: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -362,6 +382,10 @@ pub struct JudgeChangeArgs {
     /// Maximum number of candidate symbols to return (default 3, max 5).
     #[arg(long)]
     pub limit: Option<usize>,
+
+    /// Optional workspace/package/slice hint for monorepos, e.g. backend or web.
+    #[arg(long)]
+    pub scope: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -385,6 +409,10 @@ pub struct FlowArgs {
     /// Include the handler function source inline.
     #[arg(long)]
     pub include_source: bool,
+
+    /// Optional workspace/package/slice hint for monorepos, e.g. backend or web.
+    #[arg(long)]
+    pub scope: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -678,6 +706,10 @@ pub struct AskArgs {
     /// Optional file path substring to restrict scope.
     #[arg(long)]
     pub file: Option<String>,
+
+    /// Optional workspace/package/slice hint for monorepos, e.g. backend or web.
+    #[arg(long)]
+    pub scope: Option<String>,
 }
 
 pub async fn run(command: Option<Command>) -> anyhow::Result<()> {
@@ -838,7 +870,8 @@ async fn run_inspect(args: InspectArgs) -> anyhow::Result<()> {
 }
 
 async fn run_routes(args: RoutesArgs) -> anyhow::Result<()> {
-    let json = crate::engine::all_endpoints(args.path)?;
+    let json =
+        crate::engine::all_endpoints(args.path, args.query, args.method, args.scope, args.limit)?;
     println!("{json}");
     Ok(())
 }
@@ -851,14 +884,21 @@ async fn run_impact(args: ImpactArgs) -> anyhow::Result<()> {
         args.method,
         args.depth,
         Some(args.include_source),
+        args.scope,
     )?;
     println!("{json}");
     Ok(())
 }
 
 async fn run_judge_change(args: JudgeChangeArgs) -> anyhow::Result<()> {
-    let json =
-        crate::engine::judge_change(args.path, args.query, args.symbol, args.file, args.limit)?;
+    let json = crate::engine::judge_change(
+        args.path,
+        args.query,
+        args.symbol,
+        args.file,
+        args.limit,
+        args.scope,
+    )?;
     println!("{json}");
     Ok(())
 }
@@ -870,6 +910,7 @@ async fn run_flow(args: FlowArgs) -> anyhow::Result<()> {
         args.method,
         args.depth,
         args.include_source,
+        args.scope,
     )?;
     println!("{json}");
     Ok(())
@@ -1155,7 +1196,8 @@ async fn run_delete(args: DeleteArgs) -> anyhow::Result<()> {
 }
 
 async fn run_ask(args: AskArgs) -> anyhow::Result<()> {
-    let json = crate::engine::semantic_search(args.path, args.query, args.limit, args.file)?;
+    let json =
+        crate::engine::semantic_search(args.path, args.query, args.limit, args.file, args.scope)?;
     println!("{json}");
     Ok(())
 }

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -2,22 +2,117 @@ use anyhow::{anyhow, Result};
 
 use super::graph::trace_chain;
 use super::types::{AllEndpointsPayload, EndpointSummary, FlowHandlerInfo, FlowPayload};
-use super::util::{require_bake_index, resolve_project_root};
+use super::util::{
+    backend_scope_boost, bake_scope_dependencies, bake_scopes, effective_scope,
+    is_backend_endpoint_task, matches_scope_filter, require_bake_index, resolve_project_root,
+    scope_hints,
+};
+
+fn endpoint_match_score(
+    endpoint: &crate::lang::IndexedEndpoint,
+    query: Option<&str>,
+    method: Option<&str>,
+    prefer_backend: bool,
+) -> Option<i32> {
+    let method_uc = method.map(|value| value.to_uppercase());
+    if method_uc
+        .as_ref()
+        .map(|value| endpoint.method != *value)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let mut score = 0i32;
+    if let Some(query) = query {
+        let needle = query.to_lowercase();
+        let path_lc = endpoint.path.to_lowercase();
+        let handler_lc = endpoint
+            .handler_name
+            .as_deref()
+            .unwrap_or("")
+            .to_lowercase();
+        let file_lc = endpoint.file.to_lowercase();
+
+        if path_lc == needle {
+            score += 100;
+        } else if path_lc.contains(&needle) {
+            score += 70;
+        } else if handler_lc.contains(&needle) || file_lc.contains(&needle) {
+            score += 25;
+        } else {
+            return None;
+        }
+    }
+
+    if prefer_backend {
+        score += backend_scope_boost(&endpoint.file, &endpoint.language);
+    }
+
+    Some(score)
+}
 
 /// Public entrypoint for the `all_endpoints` tool: list Express-style endpoints.
-pub fn all_endpoints(path: Option<String>) -> Result<String> {
+pub fn all_endpoints(
+    path: Option<String>,
+    query: Option<String>,
+    method: Option<String>,
+    scope: Option<String>,
+    limit: Option<usize>,
+) -> Result<String> {
     let root = resolve_project_root(path)?;
     let bake = require_bake_index(&root)?;
+    let scopes = bake_scopes(&bake);
+    let scope_dependencies = bake_scope_dependencies(&bake);
+    let scoping_hints = scope_hints(&scopes, &scope_dependencies);
+    let prefer_backend =
+        is_backend_endpoint_task(query.as_deref(), query.as_deref(), None, scope.as_deref());
+    let scope_used = effective_scope(
+        &bake.files,
+        scope.as_deref(),
+        query.as_deref(),
+        query.as_deref(),
+        None,
+        None,
+    );
 
-    let endpoints: Vec<EndpointSummary> = bake
+    let mut endpoints: Vec<(i32, EndpointSummary)> = bake
         .endpoints
         .iter()
-        .map(|e| EndpointSummary {
-            method: e.method.clone(),
-            path: e.path.clone(),
-            file: e.file.clone(),
-            handler_name: e.handler_name.clone(),
+        .filter(|endpoint| {
+            matches_scope_filter(&endpoint.file, &endpoint.language, scope_used.as_deref())
         })
+        .filter_map(|endpoint| {
+            let score = endpoint_match_score(
+                endpoint,
+                query.as_deref(),
+                method.as_deref(),
+                prefer_backend,
+            )?;
+            Some((
+                score,
+                EndpointSummary {
+                    method: endpoint.method.clone(),
+                    path: endpoint.path.clone(),
+                    file: endpoint.file.clone(),
+                    handler_name: endpoint.handler_name.clone(),
+                },
+            ))
+        })
+        .collect();
+    endpoints.sort_by(|left, right| {
+        right
+            .0
+            .cmp(&left.0)
+            .then(left.1.path.cmp(&right.1.path))
+            .then(left.1.file.cmp(&right.1.file))
+    });
+    if let Some(limit) = limit {
+        endpoints.truncate(limit);
+    }
+    let endpoints = endpoints
+        .into_iter()
+        .map(|(_, endpoint)| endpoint)
         .collect();
 
     let payload = AllEndpointsPayload {
@@ -25,6 +120,11 @@ pub fn all_endpoints(path: Option<String>) -> Result<String> {
         version: env!("CARGO_PKG_VERSION"),
         project_root: root,
         endpoints,
+        scope_used: scope_used.clone(),
+        scoping_hints,
+        next_hint: scope_used.map(|value| {
+            format!("Use scope='{value}' again for backend endpoint work, or switch scopes if you need frontend/test routes.")
+        }),
     };
 
     let json = serde_json::to_string_pretty(&payload)?;
@@ -44,24 +144,41 @@ pub fn flow(
     method: Option<String>,
     depth: Option<usize>,
     include_source: bool,
+    scope: Option<String>,
 ) -> Result<String> {
     let root = resolve_project_root(path)?;
     let bake = require_bake_index(&root)?;
+    let scoping_hints = scope_hints(&bake_scopes(&bake), &bake_scope_dependencies(&bake));
+    let scope_used = effective_scope(
+        &bake.files,
+        scope.as_deref(),
+        Some(endpoint.as_str()),
+        Some(endpoint.as_str()),
+        None,
+        None,
+    );
 
-    let method_uc = method.map(|m| m.to_uppercase());
-    let endpoint_lc = endpoint.to_lowercase();
-
-    // Find matching endpoint
     let ep = bake
         .endpoints
         .iter()
-        .find(|e| {
-            e.path.to_lowercase().contains(&endpoint_lc)
-                && method_uc.as_ref().map(|m| &e.method == m).unwrap_or(true)
+        .filter(|candidate| {
+            matches_scope_filter(&candidate.file, &candidate.language, scope_used.as_deref())
         })
+        .filter_map(|candidate| {
+            endpoint_match_score(
+                candidate,
+                Some(endpoint.as_str()),
+                method.as_deref(),
+                true,
+            )
+            .map(|score| (score, candidate))
+        })
+        .max_by(|left, right| left.0.cmp(&right.0))
+        .map(|(_, endpoint)| endpoint)
         .ok_or_else(|| {
             anyhow!(
-                "No endpoint matching '{}'. Run `all_endpoints` to list available routes.",
+                "No endpoint matching '{}'. Run `routes(query=\"{}\", scope=\"backend\")` or switch to symbol-first search/inspect if generated wiring hides the route.",
+                endpoint,
                 endpoint
             )
         })?;
@@ -76,17 +193,33 @@ pub fn flow(
     // Find handler function in index
     let handler_lc = handler_name.to_lowercase();
     let ep_file_lc = ep.file.to_lowercase();
-    let start = bake
-        .functions
-        .iter()
-        .find(|f| {
-            f.name.to_lowercase() == handler_lc && f.file.to_lowercase().contains(&ep_file_lc)
-        })
-        .or_else(|| {
-            bake.functions
-                .iter()
-                .find(|f| f.name.to_lowercase() == handler_lc)
+    let start = {
+        let mut matches: Vec<&crate::lang::IndexedFunction> = bake
+            .functions
+            .iter()
+            .filter(|function| function.name.to_lowercase() == handler_lc)
+            .collect();
+        matches.sort_by(|left, right| {
+            let left_file = left.file.to_lowercase();
+            let right_file = right.file.to_lowercase();
+            let left_same_file = left_file.contains(&ep_file_lc);
+            let right_same_file = right_file.contains(&ep_file_lc);
+            right_same_file.cmp(&left_same_file).then(
+                backend_scope_boost(&right.file, &right.language)
+                    .cmp(&backend_scope_boost(&left.file, &left.language)),
+            )
         });
+        matches
+            .into_iter()
+            .find(|function| {
+                matches_scope_filter(&function.file, &function.language, scope_used.as_deref())
+            })
+            .or_else(|| {
+                bake.functions
+                    .iter()
+                    .find(|function| function.name.to_lowercase() == handler_lc)
+            })
+    };
 
     let ep_summary = EndpointSummary {
         method: ep.method.clone(),
@@ -186,11 +319,13 @@ pub fn flow(
         project_root: root,
         endpoint: ep_summary,
         handler: handler_info,
+        scope_used,
         call_chain,
         boundaries,
         unresolved,
         summary,
         chain_warning,
+        scoping_hints,
         next_hint: Some("Use inspect(name=...) on the handler or a downstream callee to read the code behind this route."),
     };
     Ok(serde_json::to_string_pretty(&payload)?)
@@ -205,6 +340,7 @@ pub fn impact(
     method: Option<String>,
     depth: Option<usize>,
     include_source: Option<bool>,
+    scope: Option<String>,
 ) -> Result<String> {
     let root = resolve_project_root(path.clone())?;
 
@@ -228,8 +364,16 @@ pub fn impact(
             serde_json::json!({
                 "endpoint": endpoint,
                 "method": method,
+                "scope": scope,
             }),
-            crate::engine::flow(path, endpoint, method, depth, include_source.unwrap_or(false))?,
+            crate::engine::flow(
+                path,
+                endpoint,
+                method,
+                depth,
+                include_source.unwrap_or(false),
+                scope,
+            )?,
             "Use inspect(name=...) on the handler or downstream callee, or change(action=edit|rename|move) once you know where the request path lands.",
         )
     } else {

--- a/src/engine/db.rs
+++ b/src/engine/db.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection};
 
-use crate::engine::types::{BakeFile, BakeIndex};
+use crate::engine::types::{BakeFile, BakeIndex, ScopeDependency, ScopeSummary};
 use crate::lang::{
     CallSite, FieldInfo, IndexedEndpoint, IndexedFunction, IndexedImpl, IndexedType,
     SignatureParam, Visibility,
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS languages (
 CREATE TABLE IF NOT EXISTS files (
     path     TEXT PRIMARY KEY,
     language TEXT NOT NULL,
+    scope_name TEXT NOT NULL DEFAULT '',
+    scope_tags TEXT NOT NULL DEFAULT '[]',
     bytes    INTEGER NOT NULL,
     mtime_ns INTEGER NOT NULL DEFAULT 0,
     origin   TEXT NOT NULL,
@@ -33,6 +35,7 @@ CREATE TABLE IF NOT EXISTS functions (
     name              TEXT    NOT NULL,
     file              TEXT    NOT NULL,
     language          TEXT    NOT NULL,
+    scope_name        TEXT    NOT NULL DEFAULT '',
     start_line        INTEGER NOT NULL,
     end_line          INTEGER NOT NULL,
     complexity        INTEGER NOT NULL,
@@ -60,6 +63,7 @@ CREATE TABLE IF NOT EXISTS types (
     name        TEXT    NOT NULL,
     file        TEXT    NOT NULL,
     language    TEXT    NOT NULL,
+    scope_name  TEXT    NOT NULL DEFAULT '',
     start_line  INTEGER NOT NULL,
     end_line    INTEGER NOT NULL,
     kind        TEXT    NOT NULL,
@@ -85,7 +89,19 @@ CREATE TABLE IF NOT EXISTS endpoints (
     file         TEXT NOT NULL,
     handler_name TEXT,
     language     TEXT NOT NULL,
-    framework    TEXT NOT NULL
+    framework    TEXT NOT NULL,
+    scope_name   TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS scopes (
+    name         TEXT PRIMARY KEY,
+    file_count   INTEGER NOT NULL,
+    languages    TEXT NOT NULL,
+    tags         TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS scope_dependencies (
+    scope        TEXT NOT NULL,
+    depends_on   TEXT NOT NULL,
+    PRIMARY KEY (scope, depends_on)
 );
 CREATE INDEX IF NOT EXISTS idx_fn_name      ON functions(name);
 CREATE INDEX IF NOT EXISTS idx_fn_file      ON functions(file);
@@ -111,6 +127,41 @@ fn str_vis(s: &str) -> Visibility {
         "module" => Visibility::Module,
         _ => Visibility::Private,
     }
+}
+
+fn rewrite_scope_metadata(
+    conn: &Connection,
+    scopes: &[ScopeSummary],
+    dependencies: &[ScopeDependency],
+) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM scopes", [])?;
+    tx.execute("DELETE FROM scope_dependencies", [])?;
+
+    {
+        let mut scope_stmt = tx.prepare(
+            "INSERT INTO scopes (name, file_count, languages, tags) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for scope in scopes {
+            scope_stmt.execute(params![
+                scope.name,
+                scope.file_count as i64,
+                serde_json::to_string(&scope.languages).unwrap_or_else(|_| "[]".into()),
+                serde_json::to_string(&scope.tags).unwrap_or_else(|_| "[]".into()),
+            ])?;
+        }
+    }
+
+    {
+        let mut dep_stmt =
+            tx.prepare("INSERT INTO scope_dependencies (scope, depends_on) VALUES (?1, ?2)")?;
+        for dep in dependencies {
+            dep_stmt.execute(params![dep.scope, dep.depends_on])?;
+        }
+    }
+
+    tx.commit()?;
+    Ok(())
 }
 
 // ── write ─────────────────────────────────────────────────────────────────────
@@ -147,11 +198,14 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
     // files
     for f in &bake.files {
         let imports = serde_json::to_string(&f.imports).unwrap_or_else(|_| "[]".into());
+        let scope_tags = serde_json::to_string(&f.scope_tags).unwrap_or_else(|_| "[]".into());
         tx.execute(
-            "INSERT OR REPLACE INTO files (path, language, bytes, mtime_ns, origin, imports) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT OR REPLACE INTO files (path, language, scope_name, scope_tags, bytes, mtime_ns, origin, imports) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 f.path.to_string_lossy().as_ref(),
                 f.language,
+                f.scope_name,
+                scope_tags,
                 f.bytes as i64,
                 f.mtime_ns,
                 f.origin,
@@ -163,10 +217,10 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
     // functions + calls
     {
         let mut fn_stmt = tx.prepare(
-            "INSERT INTO functions (name, file, language, start_line, end_line, complexity, \
+            "INSERT INTO functions (name, file, language, scope_name, start_line, end_line, complexity, \
              byte_start, byte_end, module_path, qualified_name, visibility, parent_type, \
              implemented_trait, params_json, return_type, receiver, is_stdlib, sig_hash) \
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
         )?;
         let mut call_stmt = tx.prepare(
             "INSERT INTO calls (function_id, callee, qualifier, line) VALUES (?1, ?2, ?3, ?4)",
@@ -178,6 +232,7 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
                 f.name,
                 f.file,
                 f.language,
+                f.scope_name,
                 f.start_line,
                 f.end_line,
                 f.complexity,
@@ -204,8 +259,8 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
     // types + type_fields
     {
         let mut ty_stmt = tx.prepare(
-            "INSERT INTO types (name, file, language, start_line, end_line, kind, module_path, \
-             visibility, is_stdlib) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+            "INSERT INTO types (name, file, language, scope_name, start_line, end_line, kind, module_path, \
+             visibility, is_stdlib) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
         )?;
         let mut field_stmt = tx.prepare(
             "INSERT INTO type_fields (type_id, name, type_str, visibility) VALUES (?1,?2,?3,?4)",
@@ -215,6 +270,7 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
                 t.name,
                 t.file,
                 t.language,
+                t.scope_name,
                 t.start_line,
                 t.end_line,
                 t.kind,
@@ -247,7 +303,7 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
     // endpoints
     {
         let mut ep_stmt = tx.prepare(
-            "INSERT INTO endpoints (method, path, file, handler_name, language, framework) VALUES (?1,?2,?3,?4,?5,?6)",
+            "INSERT INTO endpoints (method, path, file, handler_name, language, framework, scope_name) VALUES (?1,?2,?3,?4,?5,?6,?7)",
         )?;
         for e in &bake.endpoints {
             ep_stmt.execute(params![
@@ -256,12 +312,18 @@ pub fn write_bake_to_db(bake: &BakeIndex, db_path: &Path) -> Result<()> {
                 e.file,
                 e.handler_name,
                 e.language,
-                e.framework
+                e.framework,
+                e.scope_name,
             ])?;
         }
     }
 
     tx.commit()?;
+    rewrite_scope_metadata(
+        &conn,
+        &crate::engine::util::bake_scopes(bake),
+        &crate::engine::util::bake_scope_dependencies(bake),
+    )?;
     Ok(())
 }
 
@@ -308,6 +370,14 @@ pub fn write_bake_incremental(
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
     // Migrate older DBs that predate the mtime_ns column (error is ignored when column exists).
     let _ = conn.execute_batch("ALTER TABLE files ADD COLUMN mtime_ns INTEGER NOT NULL DEFAULT 0");
+    let _ = conn.execute_batch("ALTER TABLE files ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ =
+        conn.execute_batch("ALTER TABLE files ADD COLUMN scope_tags TEXT NOT NULL DEFAULT '[]'");
+    let _ =
+        conn.execute_batch("ALTER TABLE functions ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ = conn.execute_batch("ALTER TABLE types ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ =
+        conn.execute_batch("ALTER TABLE endpoints ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
     // Ensure all tables and indexes exist (no-op when schema is current).
     conn.execute_batch(SCHEMA)?;
 
@@ -358,11 +428,14 @@ pub fn write_bake_incremental(
         // Insert new rows for changed/new files.
         for f in &bake.files {
             let imports = serde_json::to_string(&f.imports).unwrap_or_else(|_| "[]".into());
+            let scope_tags = serde_json::to_string(&f.scope_tags).unwrap_or_else(|_| "[]".into());
             tx.execute(
-                "INSERT OR REPLACE INTO files (path, language, bytes, mtime_ns, origin, imports) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                "INSERT OR REPLACE INTO files (path, language, scope_name, scope_tags, bytes, mtime_ns, origin, imports) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     f.path.to_string_lossy().as_ref(),
                     f.language,
+                    f.scope_name,
+                    scope_tags,
                     f.bytes as i64,
                     f.mtime_ns,
                     f.origin,
@@ -373,10 +446,10 @@ pub fn write_bake_incremental(
 
         {
             let mut fn_stmt = tx.prepare(
-                "INSERT INTO functions (name, file, language, start_line, end_line, complexity, \
+                "INSERT INTO functions (name, file, language, scope_name, start_line, end_line, complexity, \
                  byte_start, byte_end, module_path, qualified_name, visibility, parent_type, \
                  implemented_trait, params_json, return_type, receiver, is_stdlib, sig_hash) \
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
             )?;
             let mut call_stmt = tx.prepare(
                 "INSERT INTO calls (function_id, callee, qualifier, line) VALUES (?1, ?2, ?3, ?4)",
@@ -387,6 +460,7 @@ pub fn write_bake_incremental(
                     f.name,
                     f.file,
                     f.language,
+                    f.scope_name,
                     f.start_line,
                     f.end_line,
                     f.complexity,
@@ -412,8 +486,8 @@ pub fn write_bake_incremental(
 
         {
             let mut ty_stmt = tx.prepare(
-                "INSERT INTO types (name, file, language, start_line, end_line, kind, module_path, \
-                 visibility, is_stdlib) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+                "INSERT INTO types (name, file, language, scope_name, start_line, end_line, kind, module_path, \
+                 visibility, is_stdlib) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
             )?;
             let mut field_stmt = tx.prepare(
                 "INSERT INTO type_fields (type_id, name, type_str, visibility) VALUES (?1,?2,?3,?4)",
@@ -423,6 +497,7 @@ pub fn write_bake_incremental(
                     t.name,
                     t.file,
                     t.language,
+                    t.scope_name,
                     t.start_line,
                     t.end_line,
                     t.kind,
@@ -453,7 +528,7 @@ pub fn write_bake_incremental(
 
         {
             let mut ep_stmt = tx.prepare(
-                "INSERT INTO endpoints (method, path, file, handler_name, language, framework) VALUES (?1,?2,?3,?4,?5,?6)",
+                "INSERT INTO endpoints (method, path, file, handler_name, language, framework, scope_name) VALUES (?1,?2,?3,?4,?5,?6,?7)",
             )?;
             for e in &bake.endpoints {
                 ep_stmt.execute(params![
@@ -463,12 +538,20 @@ pub fn write_bake_incremental(
                     e.handler_name,
                     e.language,
                     e.framework,
+                    e.scope_name,
                 ])?;
             }
         }
 
         tx.commit()?;
     }
+
+    let full_bake = read_bake_from_db(db_path)?;
+    rewrite_scope_metadata(
+        &conn,
+        &crate::engine::util::bake_scopes(&full_bake),
+        &crate::engine::util::bake_scope_dependencies(&full_bake),
+    )?;
 
     // Query totals from the now-updated DB.
     let total_files = conn
@@ -487,6 +570,16 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
         .with_context(|| format!("Failed to open bake.db at {}", db_path.display()))?;
 
     conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    let _ = conn.execute_batch("ALTER TABLE files ADD COLUMN mtime_ns INTEGER NOT NULL DEFAULT 0");
+    let _ = conn.execute_batch("ALTER TABLE files ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ =
+        conn.execute_batch("ALTER TABLE files ADD COLUMN scope_tags TEXT NOT NULL DEFAULT '[]'");
+    let _ =
+        conn.execute_batch("ALTER TABLE functions ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ = conn.execute_batch("ALTER TABLE types ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    let _ =
+        conn.execute_batch("ALTER TABLE endpoints ADD COLUMN scope_name TEXT NOT NULL DEFAULT ''");
+    conn.execute_batch(SCHEMA)?;
 
     // meta
     let version: String = conn
@@ -511,27 +604,80 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
         }
     }
 
+    let mut scopes: Vec<ScopeSummary> = Vec::new();
+    {
+        let mut stmt = conn.prepare("SELECT name, file_count, languages, tags FROM scopes")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+            ))
+        })?;
+        for row in rows {
+            let (name, file_count, languages_json, tags_json) = row?;
+            scopes.push(ScopeSummary {
+                name,
+                file_count: file_count as usize,
+                languages: serde_json::from_str(&languages_json).unwrap_or_default(),
+                tags: serde_json::from_str(&tags_json).unwrap_or_default(),
+            });
+        }
+    }
+
+    let mut scope_dependencies: Vec<ScopeDependency> = Vec::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT scope, depends_on FROM scope_dependencies ORDER BY scope, depends_on",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(ScopeDependency {
+                scope: r.get(0)?,
+                depends_on: r.get(1)?,
+            })
+        })?;
+        for row in rows {
+            scope_dependencies.push(row?);
+        }
+    }
+
     // files
     let mut files: Vec<BakeFile> = Vec::new();
     {
         let mut stmt =
-            conn.prepare("SELECT path, language, bytes, mtime_ns, origin, imports FROM files")?;
+            conn.prepare("SELECT path, language, scope_name, scope_tags, bytes, mtime_ns, origin, imports FROM files")?;
         let rows = stmt.query_map([], |r| {
             Ok((
                 r.get::<_, String>(0)?,
                 r.get::<_, String>(1)?,
-                r.get::<_, i64>(2)?,
-                r.get::<_, i64>(3)?,
-                r.get::<_, String>(4)?,
-                r.get::<_, String>(5)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, i64>(4)?,
+                r.get::<_, i64>(5)?,
+                r.get::<_, String>(6)?,
+                r.get::<_, String>(7)?,
             ))
         })?;
         for row in rows {
-            let (path, language, bytes, mtime_ns, origin, imports_json) = row?;
+            let (
+                path,
+                language,
+                scope_name,
+                scope_tags_json,
+                bytes,
+                mtime_ns,
+                origin,
+                imports_json,
+            ) = row?;
+            let scope_tags: Vec<String> =
+                serde_json::from_str(&scope_tags_json).unwrap_or_default();
             let imports: Vec<String> = serde_json::from_str(&imports_json).unwrap_or_default();
             files.push(BakeFile {
                 path: PathBuf::from(path),
                 language,
+                scope_name,
+                scope_tags,
                 bytes: bytes as u64,
                 mtime_ns,
                 origin,
@@ -545,7 +691,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
     let mut fn_ids: Vec<i64> = Vec::new();
     {
         let mut stmt = conn.prepare(
-            "SELECT id, name, file, language, start_line, end_line, complexity, byte_start, \
+            "SELECT id, name, file, language, scope_name, start_line, end_line, complexity, byte_start, \
              byte_end, module_path, qualified_name, visibility, parent_type, implemented_trait, \
              params_json, return_type, receiver, is_stdlib, sig_hash FROM functions",
         )?;
@@ -555,21 +701,22 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 r.get::<_, String>(1)?,
                 r.get::<_, String>(2)?,
                 r.get::<_, String>(3)?,
-                r.get::<_, u32>(4)?,
+                r.get::<_, String>(4)?,
                 r.get::<_, u32>(5)?,
                 r.get::<_, u32>(6)?,
-                r.get::<_, i64>(7)?,
+                r.get::<_, u32>(7)?,
                 r.get::<_, i64>(8)?,
-                r.get::<_, String>(9)?,
+                r.get::<_, i64>(9)?,
                 r.get::<_, String>(10)?,
                 r.get::<_, String>(11)?,
-                r.get::<_, Option<String>>(12)?,
+                r.get::<_, String>(12)?,
                 r.get::<_, Option<String>>(13)?,
-                r.get::<_, String>(14)?,
-                r.get::<_, Option<String>>(15)?,
+                r.get::<_, Option<String>>(14)?,
+                r.get::<_, String>(15)?,
                 r.get::<_, Option<String>>(16)?,
-                r.get::<_, i32>(17)?,
-                r.get::<_, Option<String>>(18)?,
+                r.get::<_, Option<String>>(17)?,
+                r.get::<_, i32>(18)?,
+                r.get::<_, Option<String>>(19)?,
             ))
         })?;
         for row in rows {
@@ -578,6 +725,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 name,
                 file,
                 language,
+                scope_name,
                 start_line,
                 end_line,
                 complexity,
@@ -601,6 +749,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 name,
                 file,
                 language,
+                scope_name,
                 start_line,
                 end_line,
                 complexity,
@@ -653,7 +802,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
     let mut types: Vec<IndexedType> = Vec::new();
     {
         let mut ty_stmt = conn.prepare(
-            "SELECT id, name, file, language, start_line, end_line, kind, module_path, \
+            "SELECT id, name, file, language, scope_name, start_line, end_line, kind, module_path, \
              visibility, is_stdlib FROM types",
         )?;
         let ty_rows = ty_stmt.query_map([], |r| {
@@ -662,12 +811,13 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 r.get::<_, String>(1)?,
                 r.get::<_, String>(2)?,
                 r.get::<_, String>(3)?,
-                r.get::<_, u32>(4)?,
+                r.get::<_, String>(4)?,
                 r.get::<_, u32>(5)?,
-                r.get::<_, String>(6)?,
+                r.get::<_, u32>(6)?,
                 r.get::<_, String>(7)?,
                 r.get::<_, String>(8)?,
-                r.get::<_, i32>(9)?,
+                r.get::<_, String>(9)?,
+                r.get::<_, i32>(10)?,
             ))
         })?;
         let mut ty_ids: Vec<i64> = Vec::new();
@@ -677,6 +827,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 name,
                 file,
                 language,
+                scope_name,
                 start_line,
                 end_line,
                 kind,
@@ -689,6 +840,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 name,
                 file,
                 language,
+                scope_name,
                 start_line,
                 end_line,
                 kind,
@@ -749,7 +901,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
     let mut endpoints: Vec<IndexedEndpoint> = Vec::new();
     {
         let mut stmt = conn.prepare(
-            "SELECT method, path, file, handler_name, language, framework FROM endpoints",
+            "SELECT method, path, file, handler_name, language, framework, scope_name FROM endpoints",
         )?;
         let rows = stmt.query_map([], |r| {
             Ok(IndexedEndpoint {
@@ -759,6 +911,7 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
                 handler_name: r.get(3)?,
                 language: r.get(4)?,
                 framework: r.get(5)?,
+                scope_name: r.get(6)?,
             })
         })?;
         for row in rows {
@@ -766,11 +919,24 @@ pub fn read_bake_from_db(db_path: &Path) -> Result<BakeIndex> {
         }
     }
 
+    let derived_scopes = if scopes.is_empty() {
+        Some(crate::engine::util::summarize_scopes(&files))
+    } else {
+        None
+    };
+    let derived_scope_dependencies = if scope_dependencies.is_empty() {
+        Some(crate::engine::util::summarize_scope_dependencies(&files))
+    } else {
+        None
+    };
+
     Ok(BakeIndex {
         version,
         project_root,
         languages,
         files,
+        scopes: derived_scopes.unwrap_or(scopes),
+        scope_dependencies: derived_scope_dependencies.unwrap_or(scope_dependencies),
         functions,
         endpoints,
         types,
@@ -800,6 +966,8 @@ mod tests {
             project_root: root.to_path_buf(),
             languages: BTreeSet::new(),
             files: vec![],
+            scopes: vec![],
+            scope_dependencies: vec![],
             functions: vec![],
             endpoints: vec![],
             types: vec![],
@@ -862,6 +1030,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("src/main.rs"),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes: 1024,
             mtime_ns: 0,
             origin: "local".to_string(),
@@ -870,6 +1040,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("src/lib.rs"),
             language: "rust".to_string(),
+            scope_name: String::new(),
+            scope_tags: vec![],
             bytes: 512,
             mtime_ns: 0,
             origin: "local".to_string(),
@@ -883,6 +1055,8 @@ mod tests {
             .find(|f| f.path == PathBuf::from("src/main.rs"))
             .unwrap();
         assert_eq!(main.language, "rust");
+        assert_eq!(main.scope_name, "backend");
+        assert_eq!(main.scope_tags, vec!["backend"]);
         assert_eq!(main.bytes, 1024);
         assert_eq!(main.origin, "local");
         assert_eq!(main.imports, vec!["std::fs", "anyhow"]);
@@ -901,6 +1075,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("pkg/foo.go"),
             language: "go".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes: 100,
             mtime_ns: 0,
             origin: "local".to_string(),
@@ -922,6 +1098,7 @@ mod tests {
             name: name.to_string(),
             file: format!("src/{}.rs", name),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
             start_line: 10,
             end_line: 20,
             complexity: 3,
@@ -952,6 +1129,7 @@ mod tests {
         assert_eq!(f.name, "process");
         assert_eq!(f.file, "src/process.rs");
         assert_eq!(f.language, "rust");
+        assert_eq!(f.scope_name, "backend");
         assert_eq!(f.start_line, 10);
         assert_eq!(f.end_line, 20);
         assert_eq!(f.complexity, 3);
@@ -1082,6 +1260,7 @@ mod tests {
             name: name.to_string(),
             file: "src/types.rs".to_string(),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
             start_line: 5,
             end_line: 15,
             kind: kind.to_string(),
@@ -1104,6 +1283,7 @@ mod tests {
         assert_eq!(t.kind, "struct");
         assert_eq!(t.file, "src/types.rs");
         assert_eq!(t.language, "rust");
+        assert_eq!(t.scope_name, "backend");
         assert_eq!(t.start_line, 5);
         assert_eq!(t.end_line, 15);
         assert_eq!(t.module_path, "crate::types");
@@ -1233,6 +1413,7 @@ mod tests {
             handler_name: Some("list_users".to_string()),
             language: "rust".to_string(),
             framework: "actix".to_string(),
+            scope_name: "backend".to_string(),
         });
         bake.endpoints.push(IndexedEndpoint {
             method: "POST".to_string(),
@@ -1241,6 +1422,7 @@ mod tests {
             handler_name: None,
             language: "rust".to_string(),
             framework: "actix".to_string(),
+            scope_name: "backend".to_string(),
         });
         let out = roundtrip(bake);
         assert_eq!(out.endpoints.len(), 2);
@@ -1248,8 +1430,43 @@ mod tests {
         assert_eq!(get.path, "/api/users");
         assert_eq!(get.handler_name, Some("list_users".to_string()));
         assert_eq!(get.framework, "actix");
+        assert_eq!(get.scope_name, "backend");
         let post = out.endpoints.iter().find(|e| e.method == "POST").unwrap();
         assert_eq!(post.handler_name, None);
+    }
+
+    #[test]
+    fn roundtrip_scope_metadata_and_dependencies() {
+        let dir = TempDir::new().unwrap();
+        let mut bake = empty_bake(dir.path());
+        bake.files.push(BakeFile {
+            path: PathBuf::from("backend/server.ts"),
+            language: "typescript".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
+            bytes: 100,
+            mtime_ns: 0,
+            origin: "user".to_string(),
+            imports: vec!["../generated/openapi".to_string()],
+        });
+        bake.files.push(BakeFile {
+            path: PathBuf::from("generated/openapi.ts"),
+            language: "typescript".to_string(),
+            scope_name: "generated".to_string(),
+            scope_tags: vec!["generated".to_string()],
+            bytes: 100,
+            mtime_ns: 0,
+            origin: "user".to_string(),
+            imports: vec![],
+        });
+
+        let out = roundtrip(bake);
+        assert!(out.scopes.iter().any(|scope| scope.name == "backend"));
+        assert!(out.scopes.iter().any(|scope| scope.name == "generated"));
+        assert!(out
+            .scope_dependencies
+            .iter()
+            .any(|dep| { dep.scope == "backend" && dep.depends_on == "generated" }));
     }
 
     // ── write idempotency / overwrite ────────────────────────────────────────
@@ -1290,6 +1507,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("src/main.rs"),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes: 2048,
             mtime_ns: 0,
             origin: "local".to_string(),
@@ -1323,6 +1542,7 @@ mod tests {
             handler_name: Some("health_check".to_string()),
             language: "rust".to_string(),
             framework: "actix".to_string(),
+            scope_name: "backend".to_string(),
         });
 
         let out = roundtrip(bake);
@@ -1358,6 +1578,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("src/main.rs"),
             language: "rust".to_string(),
+            scope_name: String::new(),
+            scope_tags: vec![],
             bytes: 512,
             mtime_ns: 1_700_000_000_000_000_000,
             origin: "user".to_string(),
@@ -1384,6 +1606,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("src/lib.rs"),
             language: "rust".to_string(),
+            scope_name: String::new(),
+            scope_tags: vec![],
             bytes: 1024,
             mtime_ns: 999_999_999,
             origin: "user".to_string(),
@@ -1392,6 +1616,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from("pkg/foo.go"),
             language: "go".to_string(),
+            scope_name: String::new(),
+            scope_tags: vec![],
             bytes: 2048,
             mtime_ns: 123_456_789,
             origin: "user".to_string(),
@@ -1417,6 +1643,8 @@ mod tests {
         bake.files.push(BakeFile {
             path: PathBuf::from(rel_path),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes,
             mtime_ns,
             origin: "user".to_string(),
@@ -1462,6 +1690,8 @@ mod tests {
             bake1.files.push(BakeFile {
                 path: PathBuf::from(name),
                 language: "rust".to_string(),
+                scope_name: String::new(),
+                scope_tags: vec![],
                 bytes: 100,
                 mtime_ns: 500,
                 origin: "user".to_string(),
@@ -1520,6 +1750,8 @@ mod tests {
         bake1.files.push(BakeFile {
             path: PathBuf::from("src/a.rs"),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes: 100,
             mtime_ns: 1,
             origin: "user".to_string(),
@@ -1535,6 +1767,8 @@ mod tests {
         bake2.files.push(BakeFile {
             path: PathBuf::from("src/a.rs"),
             language: "rust".to_string(),
+            scope_name: "backend".to_string(),
+            scope_tags: vec!["backend".to_string()],
             bytes: 200,
             mtime_ns: 2,
             origin: "user".to_string(),

--- a/src/engine/e2e_tests.rs
+++ b/src/engine/e2e_tests.rs
@@ -99,6 +99,7 @@ mod tests {
             None,
             None,
             Some(3),
+            None,
         )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -122,6 +123,7 @@ mod tests {
             Some("sum_three".to_string()),
             None,
             Some(3),
+            None,
         )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -393,10 +395,89 @@ pub fn fetch_user(id: u32) -> String {
         dir
     }
 
+    fn setup_mixed_scope_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join("backend")).unwrap();
+        fs::create_dir_all(dir.path().join("generated")).unwrap();
+        fs::create_dir_all(dir.path().join("web/src/tui")).unwrap();
+        fs::create_dir_all(dir.path().join("cypress/e2e")).unwrap();
+
+        fs::write(
+            dir.path().join("backend/server.ts"),
+            r#"
+import { deleteWorkflowRecord } from "../generated/openapi"
+
+app.delete("/api/v1/workflows", bulkDeleteWorkflowHandler)
+app.get("/api/v1/workflows", listWorkflowsHandler)
+
+function bulkDeleteWorkflowHandler() {
+    return deleteWorkflowRecord()
+}
+
+function listWorkflowsHandler() {
+    return "ok"
+}
+
+function persistWorkflowDelete() {
+    return "done"
+}
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            dir.path().join("generated/openapi.ts"),
+            r#"
+export function deleteWorkflowRecord() {
+    return "generated"
+}
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            dir.path().join("web/src/routes.ts"),
+            r#"
+app.delete("/api/v1/workflows-preview", bulkDeleteWorkflowRoute)
+
+function bulkDeleteWorkflowRoute() {
+    return "preview"
+}
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            dir.path().join("web/src/tui/workflows.ts"),
+            r#"
+function bulkDeleteWorkflowHandler() {
+    return "tui"
+}
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            dir.path().join("cypress/e2e/workflows.ts"),
+            r#"
+app.delete("/api/v1/workflows-fixture", bulkDeleteWorkflowFixture)
+
+function bulkDeleteWorkflowFixture() {
+    return "fixture"
+}
+"#,
+        )
+        .unwrap();
+
+        crate::engine::bake(Some(dir.path().to_string_lossy().into_owned())).unwrap();
+        dir
+    }
+
     #[test]
     fn e2e_flow_returns_endpoint_and_handler() {
         let dir = setup_with_endpoint();
-        let out = crate::engine::flow(root(&dir), "/users".into(), None, None, false).unwrap();
+        let out =
+            crate::engine::flow(root(&dir), "/users".into(), None, None, false, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 
         assert_eq!(v["tool"], "flow");
@@ -415,7 +496,8 @@ pub fn fetch_user(id: u32) -> String {
     #[test]
     fn e2e_flow_includes_call_chain() {
         let dir = setup_with_endpoint();
-        let out = crate::engine::flow(root(&dir), "/users".into(), None, Some(3), false).unwrap();
+        let out =
+            crate::engine::flow(root(&dir), "/users".into(), None, Some(3), false, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 
         let chain = v["call_chain"].as_array().unwrap();
@@ -428,7 +510,8 @@ pub fn fetch_user(id: u32) -> String {
     #[test]
     fn e2e_flow_summary_contains_endpoint_and_handler() {
         let dir = setup_with_endpoint();
-        let out = crate::engine::flow(root(&dir), "/users".into(), None, None, false).unwrap();
+        let out =
+            crate::engine::flow(root(&dir), "/users".into(), None, None, false, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 
         let summary = v["summary"].as_str().unwrap();
@@ -447,7 +530,7 @@ pub fn fetch_user(id: u32) -> String {
     #[test]
     fn e2e_flow_include_source_populates_handler_source() {
         let dir = setup_with_endpoint();
-        let out = crate::engine::flow(root(&dir), "/users".into(), None, None, true).unwrap();
+        let out = crate::engine::flow(root(&dir), "/users".into(), None, None, true, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 
         let source = v["handler"]["source"].as_str();
@@ -464,8 +547,8 @@ pub fn fetch_user(id: u32) -> String {
     #[test]
     fn e2e_flow_errors_on_unknown_endpoint() {
         let dir = setup_with_endpoint();
-        let err =
-            crate::engine::flow(root(&dir), "/nonexistent".into(), None, None, false).unwrap_err();
+        let err = crate::engine::flow(root(&dir), "/nonexistent".into(), None, None, false, None)
+            .unwrap_err();
         assert!(
             err.to_string().contains("No endpoint matching"),
             "unexpected error: {}",
@@ -482,6 +565,7 @@ pub fn fetch_user(id: u32) -> String {
             None,
             None,
             Some(1),
+            None,
             None,
         )
         .unwrap();
@@ -511,6 +595,7 @@ pub fn fetch_user(id: u32) -> String {
             None,
             Some(3),
             Some(true),
+            None,
         )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -527,6 +612,137 @@ pub fn fetch_user(id: u32) -> String {
         assert_eq!(
             v["next_hint"],
             "Use inspect(name=...) on the handler or downstream callee, or change(action=edit|rename|move) once you know where the request path lands."
+        );
+    }
+
+    #[test]
+    fn e2e_bake_reports_scope_hints_for_mixed_repo() {
+        let dir = setup_mixed_scope_repo();
+        let out = crate::engine::bake(root(&dir)).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        let scopes = v["scopes"].as_array().unwrap();
+        assert!(scopes.iter().any(|s| s["name"] == "backend"));
+        assert!(scopes.iter().any(|s| s["name"] == "generated"));
+        assert!(scopes.iter().any(|s| s["name"] == "web"));
+        assert!(scopes.iter().any(|s| s["name"] == "cypress"));
+        assert!(
+            v["scope_dependencies"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|dep| dep["scope"] == "backend" && dep["depends_on"] == "generated"),
+            "expected backend -> generated dependency: {}",
+            out
+        );
+        assert!(
+            v["scoping_hints"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|hint| hint.as_str().unwrap().contains("backend")),
+            "expected backend scoping hint: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn e2e_routes_query_prefers_backend_endpoints_in_mixed_repo() {
+        let dir = setup_mixed_scope_repo();
+        let out = crate::engine::all_endpoints(
+            root(&dir),
+            Some("/api/v1/workflows".into()),
+            Some("DELETE".into()),
+            None,
+            Some(3),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let endpoints = v["endpoints"].as_array().unwrap();
+        assert!(!endpoints.is_empty(), "expected endpoint results");
+        assert_eq!(endpoints[0]["path"], "/api/v1/workflows");
+        assert!(
+            endpoints[0]["file"]
+                .as_str()
+                .unwrap()
+                .contains("backend/server.ts"),
+            "expected backend endpoint first: {}",
+            out
+        );
+        assert_eq!(v["scope_used"], "backend");
+    }
+
+    #[test]
+    fn e2e_semantic_search_prefers_backend_handler_in_mixed_repo() {
+        let dir = setup_mixed_scope_repo();
+        let out = crate::engine::semantic_search(
+            root(&dir),
+            "bulk delete workflow handler".into(),
+            Some(5),
+            None,
+            None,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let results = v["results"].as_array().unwrap();
+        assert!(!results.is_empty(), "expected semantic results");
+        assert_eq!(results[0]["name"], "bulkDeleteWorkflowHandler");
+        assert!(
+            results[0]["file"]
+                .as_str()
+                .unwrap()
+                .contains("backend/server.ts"),
+            "expected backend handler first: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn e2e_judge_change_prefers_backend_scope_in_mixed_repo() {
+        let dir = setup_mixed_scope_repo();
+        let out = crate::engine::judge_change(
+            root(&dir),
+            "fix bulk delete workflow handler for the api endpoint".to_string(),
+            None,
+            None,
+            Some(3),
+            None,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let top = &v["candidate_symbols"].as_array().unwrap()[0];
+        assert_eq!(top["name"], "bulkDeleteWorkflowHandler");
+        assert!(
+            top["file"].as_str().unwrap().contains("backend/server.ts"),
+            "expected backend ownership candidate first: {}",
+            out
+        );
+        assert_eq!(v["scope_used"], "backend");
+    }
+
+    #[test]
+    fn e2e_impact_endpoint_mode_prefers_backend_handler_in_mixed_repo() {
+        let dir = setup_mixed_scope_repo();
+        let out = crate::engine::impact(
+            root(&dir),
+            None,
+            Some("/api/v1/workflows".into()),
+            Some("DELETE".into()),
+            Some(3),
+            Some(false),
+            None,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(v["handler"]["name"], "bulkDeleteWorkflowHandler");
+        assert!(
+            v["handler"]["file"]
+                .as_str()
+                .unwrap()
+                .contains("backend/server.ts"),
+            "expected backend handler in impact endpoint mode: {}",
+            out
         );
     }
 
@@ -1866,7 +2082,8 @@ fn get_registry() -> &'static Vec<ToolEntry> {
             .unwrap();
         }
         let out =
-            crate::engine::semantic_search(root(&dir), "add numbers".into(), None, None).unwrap();
+            crate::engine::semantic_search(root(&dir), "add numbers".into(), None, None, None)
+                .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         // note should be absent — embeddings.db exists, no need to warn
         assert!(
@@ -1883,7 +2100,8 @@ fn get_registry() -> &'static Vec<ToolEntry> {
         let _ = std::fs::remove_file(dir.path().join("bakes/latest/embeddings.db"));
 
         let out =
-            crate::engine::semantic_search(root(&dir), "compute sum".into(), None, None).unwrap();
+            crate::engine::semantic_search(root(&dir), "compute sum".into(), None, None, None)
+                .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let note = v["note"]
             .as_str()
@@ -1905,7 +2123,8 @@ fn get_registry() -> &'static Vec<ToolEntry> {
         let dir = setup();
         let _ = std::fs::remove_file(dir.path().join("bakes/latest/embeddings.db"));
 
-        let out = crate::engine::semantic_search(root(&dir), "add".into(), Some(5), None).unwrap();
+        let out =
+            crate::engine::semantic_search(root(&dir), "add".into(), Some(5), None, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let results = v["results"].as_array().unwrap();
         // Fixture has an `add` function — it should rank near the top

--- a/src/engine/index.rs
+++ b/src/engine/index.rs
@@ -27,6 +27,9 @@ pub fn llm_instructions(path: Option<String>) -> Result<String> {
         "project_root": root,
         "languages": snapshot.languages.into_iter().collect::<Vec<_>>(),
         "files_indexed": snapshot.files_indexed,
+        "scopes": snapshot.scopes,
+        "scope_dependencies": snapshot.scope_dependencies,
+        "scoping_hints": snapshot.scoping_hints,
         "tools": groups,
         "capabilities": capability_catalog(),
         "common_tasks": common_task_catalog(),
@@ -1137,6 +1140,11 @@ pub fn bake(path: Option<String>) -> Result<String> {
         });
     }
 
+    let full_bake = load_bake_index(&root)?.unwrap_or(bake);
+    let scopes = super::util::bake_scopes(&full_bake);
+    let scope_dependencies = super::util::bake_scope_dependencies(&full_bake);
+    let scoping_hints = super::util::scope_hints(&scopes, &scope_dependencies);
+
     let summary = BakeSummary {
         tool: "bake",
         version: env!("CARGO_PKG_VERSION"),
@@ -1144,7 +1152,10 @@ pub fn bake(path: Option<String>) -> Result<String> {
         bake_path,
         files_indexed: total_files,
         languages: all_languages,
+        scopes,
+        scope_dependencies,
         files_skipped: if skipped > 0 { Some(skipped) } else { None },
+        scoping_hints,
     };
 
     let out = serde_json::to_string_pretty(&summary)?;

--- a/src/engine/judge.rs
+++ b/src/engine/judge.rs
@@ -8,7 +8,10 @@ use super::types::{
     JudgeCandidateFile, JudgeCandidateSymbol, JudgeChangePayload, JudgeCommand, JudgeFinding,
     JudgeOwnershipLayer, JudgeRejectedAlternative,
 };
-use super::util::{require_bake_index, resolve_project_root};
+use super::util::{
+    backend_scope_boost, bake_scope_dependencies, bake_scopes, effective_scope,
+    matches_scope_filter, require_bake_index, resolve_project_root, scope_hints,
+};
 
 #[derive(Clone)]
 struct Candidate {
@@ -30,11 +33,21 @@ pub fn judge_change(
     symbol: Option<String>,
     file: Option<String>,
     limit: Option<usize>,
+    scope: Option<String>,
 ) -> Result<String> {
     let root = resolve_project_root(path)?;
     let bake = require_bake_index(&root)?;
     let limit = limit.unwrap_or(3).clamp(1, 5);
     let file_filter = file.as_deref().map(str::to_lowercase);
+    let scope_used = effective_scope(
+        &bake.files,
+        scope.as_deref(),
+        Some(query.as_str()),
+        None,
+        symbol.as_deref(),
+        file.as_deref(),
+    );
+    let scoping_hints = scope_hints(&bake_scopes(&bake), &bake_scope_dependencies(&bake));
 
     let mut caller_names_by_symbol: HashMap<String, HashSet<String>> = HashMap::new();
     let mut caller_files_by_symbol: HashMap<String, HashSet<String>> = HashMap::new();
@@ -60,7 +73,9 @@ pub fn judge_change(
             .iter()
             .filter(|f| f.name.to_lowercase() == needle)
         {
-            if matches_file_filter(&func.file, file_filter.as_deref()) {
+            if matches_file_filter(&func.file, file_filter.as_deref())
+                && matches_scope_filter(&func.file, &func.language, scope_used.as_deref())
+            {
                 upsert_candidate(
                     &mut candidates,
                     Candidate {
@@ -68,7 +83,7 @@ pub fn judge_change(
                         file: func.file.clone(),
                         start_line: func.start_line,
                         kind: "function",
-                        score: 100.0,
+                        score: 100.0 + backend_scope_boost(&func.file, &func.language) as f32,
                         why_parts: BTreeSet::from([format!(
                             "Matches explicit symbol hint '{}'.",
                             hint
@@ -93,7 +108,9 @@ pub fn judge_change(
             .iter()
             .filter(|t| t.name.to_lowercase() == needle)
         {
-            if matches_file_filter(&ty.file, file_filter.as_deref()) {
+            if matches_file_filter(&ty.file, file_filter.as_deref())
+                && matches_scope_filter(&ty.file, &ty.language, scope_used.as_deref())
+            {
                 upsert_candidate(
                     &mut candidates,
                     Candidate {
@@ -101,7 +118,7 @@ pub fn judge_change(
                         file: ty.file.clone(),
                         start_line: ty.start_line,
                         kind: "type",
-                        score: 95.0,
+                        score: 95.0 + backend_scope_boost(&ty.file, &ty.language) as f32,
                         why_parts: BTreeSet::from([format!(
                             "Matches explicit symbol hint '{}'.",
                             hint
@@ -117,9 +134,14 @@ pub fn judge_change(
     }
 
     let semantic_limit = limit.max(3) * 4;
-    for (score, func) in
-        semantic_candidates(&root, &bake, &query, file_filter.as_deref(), semantic_limit)
-    {
+    for (score, func) in semantic_candidates(
+        &root,
+        &bake,
+        &query,
+        file_filter.as_deref(),
+        scope_used.as_deref(),
+        semantic_limit,
+    ) {
         upsert_candidate(
             &mut candidates,
             Candidate {
@@ -163,12 +185,14 @@ pub fn judge_change(
                 why: "No strongly grounded candidates were found for this query. Narrow with a symbol or file hint, or inspect the likely area first.".to_string(),
                 evidence_files: vec![],
             },
+            scope_used,
             candidate_symbols: vec![],
             candidate_files: vec![],
             rejected_alternatives: vec![],
             invariants: vec![],
             regression_risks: vec![],
             verification_commands,
+            scoping_hints,
             next_hint: Some("Add a symbol or file hint, or use inspect(...) on the likely area before changing code."),
         };
         return Ok(serde_json::to_string_pretty(&payload)?);
@@ -224,6 +248,7 @@ pub fn judge_change(
         query,
         symbol_hint: symbol,
         file_hint: file,
+        scope_used,
         ownership_layer,
         candidate_symbols,
         candidate_files,
@@ -231,6 +256,7 @@ pub fn judge_change(
         invariants,
         regression_risks,
         verification_commands,
+        scoping_hints,
         next_hint: Some("Use change(action=...) once you accept the ownership layer, or inspect(...) to drill into one candidate before writing."),
     };
 
@@ -242,6 +268,7 @@ fn semantic_candidates<'a>(
     bake: &'a crate::engine::types::BakeIndex,
     query: &str,
     file_filter: Option<&str>,
+    scope_filter: Option<&str>,
     limit: usize,
 ) -> Vec<(f32, &'a crate::lang::IndexedFunction)> {
     let bake_dir = root.join("bakes").join("latest");
@@ -256,7 +283,12 @@ fn semantic_candidates<'a>(
         let mut ranked = Vec::new();
         for m in matches {
             if let Some(func) = lookup.get(&(m.name.as_str(), m.file.as_str(), m.start_line)) {
-                ranked.push((m.score * 10.0, *func));
+                if matches_scope_filter(&func.file, &func.language, scope_filter) {
+                    ranked.push((
+                        m.score * 10.0 + backend_scope_boost(&func.file, &func.language) as f32,
+                        *func,
+                    ));
+                }
             }
         }
         if !ranked.is_empty() {
@@ -285,8 +317,10 @@ fn semantic_candidates<'a>(
         .functions
         .iter()
         .filter(|f| matches_file_filter(&f.file, file_filter))
+        .filter(|f| matches_scope_filter(&f.file, &f.language, scope_filter))
         .filter_map(|f| {
-            let score = score_fn(f, &query_tokens, &idf);
+            let score =
+                score_fn(f, &query_tokens, &idf) + backend_scope_boost(&f.file, &f.language) as f32;
             (score > 0.0).then_some((score, f))
         })
         .collect();

--- a/src/engine/script.rs
+++ b/src/engine/script.rs
@@ -209,6 +209,7 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
                 query,
                 None,
                 None,
+                None,
             ))
         });
     }
@@ -223,6 +224,7 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
                         .ok_or_else(|| anyhow!("Missing required 'query' argument for ask"))?,
                     uint_opt(&args, "limit"),
                     str_opt(&args, "file"),
+                    str_opt(&args, "scope"),
                 )
             })();
             call_to_dynamic(res)
@@ -241,6 +243,7 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
                     str_opt(&args, "symbol"),
                     str_opt(&args, "file"),
                     uint_opt(&args, "limit"),
+                    str_opt(&args, "scope"),
                 )
             })();
             call_to_dynamic(res)
@@ -273,7 +276,29 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
     {
         let rc = r.clone();
         engine.register_fn("routes", move || -> Dynamic {
-            call_to_dynamic(crate::engine::all_endpoints(Some(rc.clone())))
+            call_to_dynamic(crate::engine::all_endpoints(
+                Some(rc.clone()),
+                None,
+                None,
+                None,
+                None,
+            ))
+        });
+    }
+    {
+        let rc = r.clone();
+        engine.register_fn("routes", move |args: RhaiMap| -> Dynamic {
+            let res = (|| {
+                let args = json_args(args)?;
+                crate::engine::all_endpoints(
+                    Some(rc.clone()),
+                    str_opt(&args, "query"),
+                    str_opt(&args, "method"),
+                    str_opt(&args, "scope"),
+                    uint_opt(&args, "limit"),
+                )
+            })();
+            call_to_dynamic(res)
         });
     }
     {
@@ -288,6 +313,7 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
                     str_opt(&args, "method"),
                     uint_opt(&args, "depth"),
                     bool_opt(&args, "include_source"),
+                    str_opt(&args, "scope"),
                 )
             })();
             call_to_dynamic(res)

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -7,7 +7,10 @@ use super::types::{
     SupersearchMatch, SupersearchPayload, SymbolMatch, SymbolPayload, TypeInspectMatch,
     TypeMethodSummary,
 };
-use super::util::{require_bake_index, resolve_project_root};
+use super::util::{
+    backend_scope_boost, bake_scope_dependencies, bake_scopes, effective_scope,
+    matches_scope_filter, require_bake_index, resolve_project_root, scope_hints,
+};
 
 /// Cap on lines returned by include_source. Prevents context overflow on monster functions.
 /// Functions exceeding this get the first N lines + a slice hint pointing at the rest.
@@ -1254,11 +1257,15 @@ mod semantic_note_tests {
             files: vec![BakeFile {
                 path: std::path::PathBuf::from("src/lib.rs"),
                 language: "rust".to_string(),
+                scope_name: String::new(),
+                scope_tags: vec![],
                 bytes: 10,
                 mtime_ns: 0,
                 origin: "user".to_string(),
                 imports: vec![],
             }],
+            scopes: vec![],
+            scope_dependencies: vec![],
             functions: vec![],
             endpoints: vec![],
             types: vec![],
@@ -1275,6 +1282,7 @@ mod semantic_note_tests {
         let out = crate::engine::semantic_search(
             Some(dir.path().to_string_lossy().into_owned()),
             "add numbers".into(),
+            None,
             None,
             None,
         )
@@ -1305,6 +1313,7 @@ mod semantic_note_tests {
             Some(dir.path().to_string_lossy().into_owned()),
             "function".into(),
             Some(5),
+            None,
             None,
         );
         // Should succeed (TF-IDF fallback), not error.
@@ -1665,11 +1674,22 @@ pub fn semantic_search(
     query: String,
     limit: Option<usize>,
     file: Option<String>,
+    scope: Option<String>,
 ) -> Result<String> {
     let root = resolve_project_root(path)?;
     let limit = limit.unwrap_or(10).min(50);
     let file_filter = file.as_deref().map(str::to_lowercase);
     let bake_dir = root.join("bakes").join("latest");
+    let bake = require_bake_index(&root)?;
+    let scope_used = effective_scope(
+        &bake.files,
+        scope.as_deref(),
+        Some(query.as_str()),
+        None,
+        None,
+        file.as_deref(),
+    );
+    let scoping_hints = scope_hints(&bake_scopes(&bake), &bake_scope_dependencies(&bake));
 
     // Try vector search first. embeddings.db is absent while the background
     // build (started by bake) is still running — in that case we fall through
@@ -1679,26 +1699,80 @@ pub fn semantic_search(
         if let Ok(Some(matches)) =
             crate::engine::embed::vector_search(&bake_dir, &query, limit, file_filter.as_deref())
         {
-            let results: Vec<SemanticMatch> = matches
-                .into_iter()
-                .map(|m| SemanticMatch {
-                    name: m.name,
-                    file: m.file,
-                    start_line: m.start_line,
-                    score: m.score,
-                    parent_type: m.parent_type,
-                    kind: "function",
+            let lookup: std::collections::HashMap<
+                (&str, &str, u32),
+                &crate::lang::IndexedFunction,
+            > = bake
+                .functions
+                .iter()
+                .map(|function| {
+                    (
+                        (
+                            function.name.as_str(),
+                            function.file.as_str(),
+                            function.start_line,
+                        ),
+                        function,
+                    )
                 })
                 .collect();
-            let payload = SemanticSearchPayload {
-                tool: "semantic_search",
-                version: env!("CARGO_PKG_VERSION"),
-                project_root: root,
-                query,
-                results,
-                note: None,
-            };
-            return Ok(serde_json::to_string_pretty(&payload)?);
+            let mut results: Vec<SemanticMatch> = matches
+                .into_iter()
+                .filter_map(|matched| {
+                    let matched_name = matched.name.clone();
+                    let matched_file = matched.file.clone();
+                    let boost = {
+                        let function = lookup.get(&(
+                            matched_name.as_str(),
+                            matched_file.as_str(),
+                            matched.start_line,
+                        ))?;
+                        if file_filter
+                            .as_deref()
+                            .map(|needle| !function.file.to_lowercase().contains(needle))
+                            .unwrap_or(false)
+                        {
+                            return None;
+                        }
+                        if !super::util::matches_scope_filter(
+                            &function.file,
+                            &function.language,
+                            scope_used.as_deref(),
+                        ) {
+                            return None;
+                        }
+                        backend_scope_boost(&function.file, &function.language) as f32 / 100.0
+                    };
+                    Some(SemanticMatch {
+                        name: matched_name,
+                        file: matched_file,
+                        start_line: matched.start_line,
+                        score: matched.score + boost,
+                        parent_type: matched.parent_type,
+                        kind: "function",
+                    })
+                })
+                .collect();
+            results.sort_by(|left, right| {
+                right
+                    .score
+                    .partial_cmp(&left.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            results.truncate(limit);
+            if !results.is_empty() {
+                let payload = SemanticSearchPayload {
+                    tool: "semantic_search",
+                    version: env!("CARGO_PKG_VERSION"),
+                    project_root: root,
+                    query,
+                    results,
+                    scope_used,
+                    note: None,
+                    scoping_hints,
+                };
+                return Ok(serde_json::to_string_pretty(&payload)?);
+            }
         }
     }
 
@@ -1708,8 +1782,6 @@ pub fn semantic_search(
     } else {
         None
     };
-    let bake = require_bake_index(&root)?;
-
     let query_tokens = tokenize(&query);
     if query_tokens.is_empty() {
         return Err(anyhow!("Query produced no tokens after tokenisation."));
@@ -1738,8 +1810,10 @@ pub fn semantic_search(
                 .as_deref()
                 .map_or(true, |ff| f.file.to_lowercase().contains(ff))
         })
+        .filter(|f| matches_scope_filter(&f.file, &f.language, scope_used.as_deref()))
         .filter_map(|f| {
-            let s = score_fn(f, &query_tokens, &idf);
+            let s = score_fn(f, &query_tokens, &idf)
+                + (backend_scope_boost(&f.file, &f.language) as f32 / 10.0);
             if s > 0.0 {
                 Some((s, f))
             } else {
@@ -1769,7 +1843,9 @@ pub fn semantic_search(
         project_root: root,
         query,
         results,
+        scope_used,
         note: tfidf_note,
+        scoping_hints,
     };
     Ok(serde_json::to_string_pretty(&payload)?)
 }

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -14,6 +14,10 @@ pub(crate) struct BakeIndex {
     pub(crate) languages: BTreeSet<String>,
     pub(crate) files: Vec<BakeFile>,
     #[serde(default)]
+    pub(crate) scopes: Vec<ScopeSummary>,
+    #[serde(default)]
+    pub(crate) scope_dependencies: Vec<ScopeDependency>,
+    #[serde(default)]
     pub(crate) functions: Vec<crate::lang::IndexedFunction>,
     #[serde(default)]
     pub(crate) endpoints: Vec<crate::lang::IndexedEndpoint>,
@@ -31,6 +35,10 @@ fn default_origin() -> String {
 pub(crate) struct BakeFile {
     pub(crate) path: PathBuf,
     pub(crate) language: String,
+    #[serde(default)]
+    pub(crate) scope_name: String,
+    #[serde(default)]
+    pub(crate) scope_tags: Vec<String>,
     pub(crate) bytes: u64,
     /// Modification time in nanoseconds since UNIX epoch. Used for incremental bake.
     /// Zero means "unknown / not tracked" — file will always be re-parsed.
@@ -41,6 +49,21 @@ pub(crate) struct BakeFile {
     /// "user" for project files, "stdlib" for toolchain stdlib files.
     #[serde(default = "default_origin")]
     pub(crate) origin: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct ScopeSummary {
+    pub(crate) name: String,
+    pub(crate) file_count: usize,
+    pub(crate) languages: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tags: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ScopeDependency {
+    pub(crate) scope: String,
+    pub(crate) depends_on: String,
 }
 
 // ── Consolidated shared structs ───────────────────────────────────────────────
@@ -267,10 +290,16 @@ pub(crate) struct BakeSummary {
     pub(crate) bake_path: PathBuf,
     pub(crate) files_indexed: usize,
     pub(crate) languages: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scopes: Vec<ScopeSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scope_dependencies: Vec<ScopeDependency>,
     /// Number of files skipped because mtime+size matched the cached index.
     /// Omitted when zero (first bake or full rebuild).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) files_skipped: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scoping_hints: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -341,6 +370,12 @@ pub(crate) struct AllEndpointsPayload {
     pub(crate) version: &'static str,
     pub(crate) project_root: PathBuf,
     pub(crate) endpoints: Vec<EndpointSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope_used: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scoping_hints: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) next_hint: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -669,12 +704,16 @@ pub(crate) struct FlowPayload {
     pub(crate) project_root: PathBuf,
     pub(crate) endpoint: EndpointSummary,
     pub(crate) handler: FlowHandlerInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope_used: Option<String>,
     pub(crate) call_chain: Vec<TraceNode>,
     pub(crate) boundaries: Vec<String>,
     pub(crate) unresolved: Vec<String>,
     pub(crate) summary: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) chain_warning: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scoping_hints: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) next_hint: Option<&'static str>,
 }
@@ -817,10 +856,14 @@ pub(crate) struct SemanticSearchPayload {
     pub(crate) project_root: PathBuf,
     pub(crate) query: String,
     pub(crate) results: Vec<SemanticMatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope_used: Option<String>,
     /// Present when the embeddings index is not yet ready. Results are TF-IDF
     /// until the background build (started by bake) finishes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) note: Option<&'static str>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scoping_hints: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -846,6 +889,8 @@ pub(crate) struct JudgeChangePayload {
     pub(crate) symbol_hint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) file_hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope_used: Option<String>,
     pub(crate) ownership_layer: JudgeOwnershipLayer,
     pub(crate) candidate_symbols: Vec<JudgeCandidateSymbol>,
     pub(crate) candidate_files: Vec<JudgeCandidateFile>,
@@ -854,6 +899,8 @@ pub(crate) struct JudgeChangePayload {
     pub(crate) invariants: Vec<JudgeFinding>,
     pub(crate) regression_risks: Vec<JudgeFinding>,
     pub(crate) verification_commands: Vec<JudgeCommand>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) scoping_hints: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) next_hint: Option<&'static str>,
 }

--- a/src/engine/util.rs
+++ b/src/engine/util.rs
@@ -4,11 +4,20 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
-use super::types::{BakeFile, BakeIndex};
+use super::types::{BakeFile, BakeIndex, ScopeDependency, ScopeSummary};
 
 pub(crate) struct Snapshot {
     pub(crate) languages: BTreeSet<String>,
     pub(crate) files_indexed: usize,
+    pub(crate) scopes: Vec<ScopeSummary>,
+    pub(crate) scope_dependencies: Vec<ScopeDependency>,
+    pub(crate) scoping_hints: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScopeProfile {
+    pub(crate) name: String,
+    pub(crate) tags: BTreeSet<String>,
 }
 
 fn requested_root(path: Option<String>) -> Result<PathBuf> {
@@ -74,9 +83,405 @@ pub(crate) fn resolve_project_root(path: Option<String>) -> Result<PathBuf> {
     Ok(find_bake_root(&root).unwrap_or(root))
 }
 
+pub(crate) fn scope_profile(path: &str, language: &str) -> ScopeProfile {
+    let normalized = path.replace('\\', "/").to_lowercase();
+    let mut parts = normalized.split('/').filter(|part| !part.is_empty());
+    let first = parts.next().unwrap_or(".");
+    let name = if matches!(first, "src" | "lib" | "app" | "internal" | "pkg" | "cmd")
+        && normalized.contains('/')
+    {
+        first.to_string()
+    } else {
+        first.to_string()
+    };
+
+    let mut tags = BTreeSet::new();
+    let lower_lang = language.to_lowercase();
+    let is_js_family = matches!(lower_lang.as_str(), "typescript" | "javascript");
+    let has_any = |needles: &[&str]| needles.iter().any(|needle| normalized.contains(needle));
+
+    if has_any(&[
+        "/test",
+        "/tests",
+        "/spec",
+        "__tests__",
+        ".test.",
+        ".spec.",
+        "cypress",
+        "playwright",
+        "/e2e",
+        "/integration",
+    ]) {
+        tags.insert("test".to_string());
+    }
+    if has_any(&["cypress", "playwright", "/e2e"]) {
+        tags.insert("e2e".to_string());
+    }
+    if has_any(&[
+        "generated",
+        "openapi",
+        "swagger",
+        "/gen/",
+        "/gen.",
+        "/generated/",
+    ]) {
+        tags.insert("generated".to_string());
+    }
+    if has_any(&[
+        "/backend",
+        "/server",
+        "/servers",
+        "/handler",
+        "/handlers",
+        "/controller",
+        "/controllers",
+        "/service",
+        "/services",
+        "/api",
+        "/internal",
+        "/cmd",
+        "/pkg",
+    ]) || name == "backend"
+    {
+        tags.insert("backend".to_string());
+    }
+    if has_any(&[
+        "/frontend",
+        "/web",
+        "/client",
+        "/ui",
+        "/components",
+        "/hooks",
+        "/pages",
+        "/tui",
+    ]) || name == "web"
+        || name == "frontend"
+    {
+        tags.insert("frontend".to_string());
+    }
+    if is_js_family && !tags.contains("backend") && !tags.contains("test") {
+        tags.insert("frontend".to_string());
+    }
+
+    ScopeProfile { name, tags }
+}
+
+fn scope_profile_for_bake_file(file: &BakeFile) -> ScopeProfile {
+    if !file.scope_name.is_empty() {
+        return ScopeProfile {
+            name: file.scope_name.clone(),
+            tags: file.scope_tags.iter().cloned().collect(),
+        };
+    }
+    scope_profile(&file.path.to_string_lossy(), &file.language)
+}
+
+pub(crate) fn matches_scope_filter(path: &str, language: &str, scope_filter: Option<&str>) -> bool {
+    let Some(scope_filter) = scope_filter else {
+        return true;
+    };
+    let needle = scope_filter.to_lowercase();
+    let profile = scope_profile(path, language);
+    profile.name == needle
+        || profile.tags.iter().any(|tag| tag == &needle)
+        || path.to_lowercase().contains(&needle)
+}
+
+pub(crate) fn is_backend_endpoint_task(
+    query: Option<&str>,
+    endpoint: Option<&str>,
+    symbol: Option<&str>,
+    file_hint: Option<&str>,
+) -> bool {
+    let combined = [query, endpoint, symbol, file_hint]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    combined.contains("/api")
+        || combined.contains("endpoint")
+        || combined.contains("route")
+        || combined.contains("handler")
+        || combined.contains("backend")
+        || combined.contains("http")
+        || combined.contains("workflow")
+}
+
+pub(crate) fn summarize_scopes(files: &[BakeFile]) -> Vec<ScopeSummary> {
+    let mut grouped: std::collections::BTreeMap<
+        String,
+        (usize, BTreeSet<String>, BTreeSet<String>),
+    > = std::collections::BTreeMap::new();
+
+    for file in files {
+        let profile = scope_profile_for_bake_file(file);
+        let entry = grouped
+            .entry(profile.name)
+            .or_insert_with(|| (0, BTreeSet::new(), BTreeSet::new()));
+        entry.0 += 1;
+        entry.1.insert(file.language.clone());
+        entry.2.extend(profile.tags);
+    }
+
+    grouped
+        .into_iter()
+        .map(|(name, (file_count, languages, tags))| ScopeSummary {
+            name,
+            file_count,
+            languages: languages.into_iter().collect(),
+            tags: tags.into_iter().collect(),
+        })
+        .collect()
+}
+
+fn import_tokens(import: &str) -> BTreeSet<String> {
+    import
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_lowercase())
+        .collect()
+}
+
+pub(crate) fn summarize_scope_dependencies(files: &[BakeFile]) -> Vec<ScopeDependency> {
+    let scope_names: BTreeSet<String> = files
+        .iter()
+        .map(|file| scope_profile_for_bake_file(file).name)
+        .filter(|name| !name.is_empty())
+        .collect();
+    let mut dependencies = BTreeSet::new();
+
+    for file in files {
+        let source_scope = scope_profile_for_bake_file(file).name;
+        if source_scope.is_empty() {
+            continue;
+        }
+        for import in &file.imports {
+            let tokens = import_tokens(import);
+            for target_scope in &scope_names {
+                if target_scope == &source_scope || !tokens.contains(target_scope) {
+                    continue;
+                }
+                dependencies.insert(ScopeDependency {
+                    scope: source_scope.clone(),
+                    depends_on: target_scope.clone(),
+                });
+            }
+        }
+    }
+
+    dependencies.into_iter().collect()
+}
+
+pub(crate) fn bake_scopes(bake: &BakeIndex) -> Vec<ScopeSummary> {
+    if bake.scopes.is_empty() {
+        summarize_scopes(&bake.files)
+    } else {
+        bake.scopes.clone()
+    }
+}
+
+pub(crate) fn bake_scope_dependencies(bake: &BakeIndex) -> Vec<ScopeDependency> {
+    if bake.scope_dependencies.is_empty() {
+        summarize_scope_dependencies(&bake.files)
+    } else {
+        bake.scope_dependencies.clone()
+    }
+}
+
+pub(crate) fn scope_hints(
+    scopes: &[ScopeSummary],
+    dependencies: &[ScopeDependency],
+) -> Vec<String> {
+    let has_backend = scopes
+        .iter()
+        .any(|scope| scope.tags.iter().any(|tag| tag == "backend"));
+    let has_frontend = scopes
+        .iter()
+        .any(|scope| scope.tags.iter().any(|tag| tag == "frontend"));
+    let has_tests = scopes
+        .iter()
+        .any(|scope| scope.tags.iter().any(|tag| tag == "test" || tag == "e2e"));
+    let has_generated = scopes
+        .iter()
+        .any(|scope| scope.tags.iter().any(|tag| tag == "generated"));
+
+    let mut hints = Vec::new();
+    if has_backend && (has_frontend || has_tests) {
+        hints.push(
+            "Mixed backend/frontend/test repo detected. For backend API work, scope reads to the backend slice first."
+                .to_string(),
+        );
+    }
+    if has_tests {
+        hints.push(
+            "Test and e2e files are indexed too. They can pollute endpoint discovery unless you scope reads."
+                .to_string(),
+        );
+    }
+    if has_generated {
+        hints.push(
+            "Generated/OpenAPI code detected. If endpoint tracing misses, fall back to symbol-first search and inspect."
+                .to_string(),
+        );
+    }
+    if dependencies.iter().any(|dep| dep.scope != dep.depends_on) {
+        hints.push(
+            "Cross-scope imports detected. Changing shared/generated code may require refreshing dependent scopes too."
+                .to_string(),
+        );
+    }
+    hints
+}
+
+fn fingerprints_from_bake(bake: &BakeIndex) -> std::collections::HashMap<String, (i64, i64)> {
+    bake.files
+        .iter()
+        .map(|file| {
+            (
+                file.path.to_string_lossy().into_owned(),
+                (file.mtime_ns, file.bytes as i64),
+            )
+        })
+        .collect()
+}
+
+fn expand_to_scope_files(
+    bake: &BakeIndex,
+    touched_files: &[String],
+) -> std::collections::HashSet<String> {
+    use std::collections::HashSet;
+
+    let reverse_dependencies = bake_scope_dependencies(bake).into_iter().fold(
+        std::collections::HashMap::<String, Vec<String>>::new(),
+        |mut acc, dep| {
+            acc.entry(dep.depends_on).or_default().push(dep.scope);
+            acc
+        },
+    );
+    let mut affected_scopes = HashSet::new();
+    let mut queue = Vec::new();
+    let mut expanded = HashSet::new();
+
+    for file in touched_files {
+        let scope_name = bake
+            .files
+            .iter()
+            .find(|indexed| indexed.path.to_string_lossy() == file.as_str())
+            .map(|indexed| {
+                if indexed.scope_name.is_empty() {
+                    scope_profile(file, &indexed.language).name
+                } else {
+                    indexed.scope_name.clone()
+                }
+            })
+            .unwrap_or_else(|| scope_profile(file, detect_language(Path::new(file))).name);
+        if affected_scopes.insert(scope_name.clone()) {
+            queue.push(scope_name);
+        }
+        expanded.insert(file.clone());
+    }
+
+    while let Some(scope_name) = queue.pop() {
+        if let Some(dependents) = reverse_dependencies.get(&scope_name) {
+            for dependent in dependents {
+                if affected_scopes.insert(dependent.clone()) {
+                    queue.push(dependent.clone());
+                }
+            }
+        }
+    }
+
+    for file in &bake.files {
+        let path = file.path.to_string_lossy().into_owned();
+        let profile = scope_profile_for_bake_file(file);
+        if affected_scopes.contains(&profile.name) {
+            expanded.insert(path);
+        }
+    }
+
+    expanded
+}
+
+fn refresh_scoped_paths(
+    root: &PathBuf,
+    bake: &BakeIndex,
+    touched_files: &[String],
+) -> Result<BakeIndex> {
+    let bake_path = bake_index_path(root);
+    let affected = expand_to_scope_files(bake, touched_files);
+    let mut fingerprints = fingerprints_from_bake(bake);
+    for path in &affected {
+        fingerprints.remove(path);
+    }
+
+    let (delta, removed, _) = build_bake_index(root, &fingerprints)?;
+    super::db::write_bake_incremental(&delta, &removed, &bake_path).with_context(|| {
+        format!(
+            "Failed to write scoped bake index update to {}",
+            bake_path.display()
+        )
+    })?;
+    super::db::read_bake_from_db(&bake_path).with_context(|| {
+        format!(
+            "Failed to read refreshed bake index from {}",
+            bake_path.display()
+        )
+    })
+}
+
+pub(crate) fn effective_scope(
+    files: &[BakeFile],
+    explicit_scope: Option<&str>,
+    query: Option<&str>,
+    endpoint: Option<&str>,
+    symbol: Option<&str>,
+    file_hint: Option<&str>,
+) -> Option<String> {
+    if let Some(scope) = explicit_scope {
+        return Some(scope.to_lowercase());
+    }
+
+    if let Some(file_hint) = file_hint {
+        return Some(scope_profile(file_hint, detect_language(Path::new(file_hint))).name);
+    }
+
+    if !is_backend_endpoint_task(query, endpoint, symbol, file_hint) {
+        return None;
+    }
+
+    summarize_scopes(files)
+        .into_iter()
+        .filter(|scope| {
+            scope.tags.iter().any(|tag| tag == "backend")
+                && !scope
+                    .tags
+                    .iter()
+                    .any(|tag| tag == "frontend" || tag == "test" || tag == "e2e")
+        })
+        .max_by(|left, right| left.file_count.cmp(&right.file_count))
+        .map(|scope| scope.name)
+}
+
+pub(crate) fn backend_scope_boost(path: &str, language: &str) -> i32 {
+    let profile = scope_profile(path, language);
+    let mut score = 0i32;
+    if profile.tags.iter().any(|tag| tag == "backend") {
+        score += 25;
+    }
+    if profile.tags.iter().any(|tag| tag == "frontend") {
+        score -= 20;
+    }
+    if profile.tags.iter().any(|tag| tag == "test" || tag == "e2e") {
+        score -= 35;
+    }
+    score
+}
+
 pub(crate) fn project_snapshot(root: &PathBuf) -> Result<Snapshot> {
     let mut languages = BTreeSet::new();
     let mut files_indexed = 0usize;
+    let mut files = Vec::new();
 
     fn walk(dir: &Path, languages: &mut BTreeSet<String>, count: &mut usize) -> Result<()> {
         for entry in fs::read_dir(dir)? {
@@ -104,11 +509,49 @@ pub(crate) fn project_snapshot(root: &PathBuf) -> Result<Snapshot> {
         Ok(())
     }
 
+    fn collect_files(root: &Path, files: &mut Vec<BakeFile>) -> Result<()> {
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if matches!(
+                        name,
+                        ".git" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
+                    ) {
+                        continue;
+                    }
+                }
+                collect_files(&path, files)?;
+            } else if path.is_file() {
+                let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+                files.push(BakeFile {
+                    path: rel,
+                    language: detect_language(&path).to_string(),
+                    scope_name: String::new(),
+                    scope_tags: vec![],
+                    bytes: 0,
+                    mtime_ns: 0,
+                    imports: vec![],
+                    origin: "user".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     walk(root, &mut languages, &mut files_indexed)?;
+    collect_files(root, &mut files)?;
+    let scopes = summarize_scopes(&files);
+    let scope_dependencies = summarize_scope_dependencies(&files);
+    let scoping_hints = scope_hints(&scopes, &scope_dependencies);
 
     Ok(Snapshot {
         languages,
         files_indexed,
+        scopes,
+        scope_dependencies,
+        scoping_hints,
     })
 }
 
@@ -128,14 +571,20 @@ pub(crate) fn load_bake_index(root: &PathBuf) -> Result<Option<BakeIndex>> {
     let bake_mtime = fs::metadata(&bake_path)
         .and_then(|m| m.modified())
         .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-    let content_stale = bake.files.iter().any(|f| {
-        fs::metadata(root.join(&f.path))
-            .and_then(|m| m.modified())
-            .map(|mtime| mtime > bake_mtime)
-            .unwrap_or(true) // missing file → reindex
-    });
+    let stale_files: Vec<String> = bake
+        .files
+        .iter()
+        .filter_map(|file| {
+            let path = file.path.to_string_lossy().into_owned();
+            let stale = fs::metadata(root.join(&file.path))
+                .and_then(|metadata| metadata.modified())
+                .map(|mtime| mtime > bake_mtime)
+                .unwrap_or(true);
+            stale.then_some(path)
+        })
+        .collect();
 
-    if version_stale || content_stale {
+    if version_stale {
         let (fresh, _, _) = build_bake_index(root, &std::collections::HashMap::new())?;
         let bakes_dir = root.join("bakes").join("latest");
         fs::create_dir_all(&bakes_dir)?;
@@ -146,6 +595,10 @@ pub(crate) fn load_bake_index(root: &PathBuf) -> Result<Option<BakeIndex>> {
             )
         })?;
         return Ok(Some(fresh));
+    }
+
+    if !stale_files.is_empty() {
+        return Ok(Some(refresh_scoped_paths(root, &bake, &stale_files)?));
     }
 
     Ok(Some(bake))
@@ -295,6 +748,7 @@ pub(crate) fn build_bake_index(
             languages.insert(lang.to_string());
         }
         let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+        let scope = scope_profile(&rel.to_string_lossy(), lang);
         let path_str = rel.to_string_lossy().into_owned();
 
         // Skip if mtime_ns+bytes match the stored fingerprint (and fingerprint is non-zero).
@@ -315,6 +769,8 @@ pub(crate) fn build_bake_index(
         files.push(BakeFile {
             path: rel,
             language: lang.to_string(),
+            scope_name: scope.name,
+            scope_tags: scope.tags.into_iter().collect(),
             bytes,
             mtime_ns,
             imports: vec![],
@@ -363,12 +819,25 @@ pub(crate) fn build_bake_index(
     let mut types = Vec::new();
     let mut impls = Vec::new();
     for (idx, funcs, eps, typs, imps, imports) in results {
-        functions.extend(funcs);
-        endpoints.extend(eps);
-        types.extend(typs);
+        let scope_name = files[idx].scope_name.clone();
+        functions.extend(funcs.into_iter().map(|mut func| {
+            func.scope_name = scope_name.clone();
+            func
+        }));
+        endpoints.extend(eps.into_iter().map(|mut endpoint| {
+            endpoint.scope_name = scope_name.clone();
+            endpoint
+        }));
+        types.extend(typs.into_iter().map(|mut typ| {
+            typ.scope_name = scope_name.clone();
+            typ
+        }));
         impls.extend(imps);
         files[idx].imports = imports;
     }
+
+    let scopes = summarize_scopes(&files);
+    let scope_dependencies = summarize_scope_dependencies(&files);
 
     Ok((
         BakeIndex {
@@ -376,6 +845,8 @@ pub(crate) fn build_bake_index(
             project_root: root.clone(),
             languages,
             files,
+            scopes,
+            scope_dependencies,
             functions,
             endpoints,
             types,
@@ -424,40 +895,22 @@ pub(crate) fn reindex_files(root: &PathBuf, changed_files: &[&str]) -> Result<()
         return Ok(());
     }
 
-    let mut bake = match super::db::read_bake_from_db(&bake_path) {
+    let bake = match super::db::read_bake_from_db(&bake_path) {
         Ok(b) => b,
         Err(_) => return Ok(()),
     };
-
-    for file in changed_files {
-        // Remove stale entries for this file.
-        bake.functions.retain(|f| f.file.as_str() != *file);
-        bake.endpoints.retain(|e| e.file.as_str() != *file);
-        bake.types.retain(|t| t.file.as_str() != *file);
-
-        // Re-analyze the file.
-        let full_path = root.join(file);
-        if !full_path.exists() {
-            continue;
-        }
-        let lang = detect_language(&full_path);
-        if let Some(analyzer) = crate::lang::find_analyzer(lang) {
-            if let Ok((funcs, eps, typs, imps)) = analyzer.analyze_file(root, &full_path) {
-                bake.functions.extend(funcs);
-                bake.endpoints.extend(eps);
-                bake.types.extend(typs);
-                bake.impls.extend(imps);
-            }
-        }
-    }
-
-    super::db::write_bake_to_db(&bake, &bake_path)?;
+    let touched: Vec<String> = changed_files
+        .iter()
+        .map(|file| (*file).to_string())
+        .collect();
+    let _ = refresh_scoped_paths(root, &bake, &touched)?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::time::Duration;
 
     use tempfile::TempDir;
 
@@ -472,6 +925,8 @@ mod tests {
             project_root: root.path().to_path_buf(),
             languages: BTreeSet::new(),
             files: vec![],
+            scopes: vec![],
+            scope_dependencies: vec![],
             functions: vec![],
             endpoints: vec![],
             types: vec![],
@@ -515,5 +970,105 @@ mod tests {
         assert_eq!(detect_language(Path::new("src/core.clj")), "clojure");
         assert_eq!(detect_language(Path::new("src/core.cljs")), "clojure");
         assert_eq!(detect_language(Path::new("src/core.cljc")), "clojure");
+    }
+
+    fn write_mixed_repo(root: &TempDir) {
+        fs::create_dir_all(root.path().join("backend")).unwrap();
+        fs::create_dir_all(root.path().join("web")).unwrap();
+        fs::write(
+            root.path().join("backend/a.ts"),
+            "function alpha() { return beta(); }\nfunction beta() { return 1; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("backend/b.ts"),
+            "function gamma() { return 2; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("web/ui.ts"),
+            "function renderUi() { return 3; }\n",
+        )
+        .unwrap();
+    }
+
+    fn write_dependency_repo(root: &TempDir) {
+        fs::create_dir_all(root.path().join("backend")).unwrap();
+        fs::create_dir_all(root.path().join("generated")).unwrap();
+        fs::create_dir_all(root.path().join("web")).unwrap();
+        fs::write(
+            root.path().join("backend/server.ts"),
+            "import { client } from \"../generated/client\";\nfunction handler() { return client(); }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("generated/client.ts"),
+            "export function client() { return 1; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("web/app.ts"),
+            "function renderUi() { return 3; }\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reindex_files_expands_to_changed_scope() {
+        let dir = TempDir::new().unwrap();
+        write_mixed_repo(&dir);
+        std::env::set_var("YOYO_SKIP_EMBED", "1");
+        crate::engine::bake(Some(dir.path().to_string_lossy().into_owned())).unwrap();
+        std::env::remove_var("YOYO_SKIP_EMBED");
+
+        fs::write(
+            dir.path().join("backend/b.ts"),
+            "function gammaUpdated() { return 4; }\n",
+        )
+        .unwrap();
+
+        reindex_files(&dir.path().to_path_buf(), &["backend/a.ts"]).unwrap();
+        let bake = require_bake_index(&dir.path().to_path_buf()).unwrap();
+
+        assert!(bake.functions.iter().any(|f| f.name == "gammaUpdated"));
+        assert!(!bake.functions.iter().any(|f| f.name == "gamma"));
+        assert!(bake.functions.iter().any(|f| f.name == "renderUi"));
+    }
+
+    #[test]
+    fn load_bake_index_refreshes_stale_scope_only() {
+        let dir = TempDir::new().unwrap();
+        write_mixed_repo(&dir);
+        std::env::set_var("YOYO_SKIP_EMBED", "1");
+        crate::engine::bake(Some(dir.path().to_string_lossy().into_owned())).unwrap();
+        std::env::remove_var("YOYO_SKIP_EMBED");
+
+        std::thread::sleep(Duration::from_millis(20));
+        fs::write(
+            dir.path().join("backend/b.ts"),
+            "function delta() { return 5; }\n",
+        )
+        .unwrap();
+
+        let bake = load_bake_index(&dir.path().to_path_buf()).unwrap().unwrap();
+        assert!(bake.functions.iter().any(|f| f.name == "delta"));
+        assert!(!bake.functions.iter().any(|f| f.name == "gamma"));
+        assert!(bake.functions.iter().any(|f| f.name == "renderUi"));
+    }
+
+    #[test]
+    fn dependency_refresh_expands_to_dependent_scopes() {
+        let dir = TempDir::new().unwrap();
+        write_dependency_repo(&dir);
+        std::env::set_var("YOYO_SKIP_EMBED", "1");
+        crate::engine::bake(Some(dir.path().to_string_lossy().into_owned())).unwrap();
+        std::env::remove_var("YOYO_SKIP_EMBED");
+
+        let bake = require_bake_index(&dir.path().to_path_buf()).unwrap();
+        let expanded = expand_to_scope_files(&bake, &["generated/client.ts".to_string()]);
+
+        assert!(expanded.contains("generated/client.ts"));
+        assert!(expanded.contains("backend/server.ts"));
+        assert!(!expanded.contains("web/app.ts"));
     }
 }

--- a/src/lang/go.rs
+++ b/src/lang/go.rs
@@ -405,6 +405,7 @@ fn extract_http_route(
         handler_name: None,
         language: "go".to_string(),
         framework: "gin/echo/net-http".to_string(),
+        scope_name: String::new(),
     })
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -56,6 +56,8 @@ pub struct IndexedFunction {
     pub name: String,
     pub file: String,
     pub language: String,
+    #[serde(default)]
+    pub scope_name: String,
     pub start_line: u32,
     pub end_line: u32,
     pub complexity: u32,
@@ -107,6 +109,7 @@ impl Default for IndexedFunction {
             name: String::new(),
             file: String::new(),
             language: String::new(),
+            scope_name: String::new(),
             start_line: 0,
             end_line: 0,
             complexity: 0,
@@ -173,6 +176,8 @@ pub struct IndexedEndpoint {
     pub handler_name: Option<String>,
     pub language: String,
     pub framework: String,
+    #[serde(default)]
+    pub scope_name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,6 +185,8 @@ pub struct IndexedType {
     pub name: String,
     pub file: String,
     pub language: String,
+    #[serde(default)]
+    pub scope_name: String,
     pub start_line: u32,
     pub end_line: u32,
     pub kind: String, // "struct" | "enum" | "trait" | "type" | "class" | "interface"
@@ -201,6 +208,7 @@ impl Default for IndexedType {
             name: String::new(),
             file: String::new(),
             language: String::new(),
+            scope_name: String::new(),
             start_line: 0,
             end_line: 0,
             kind: String::new(),

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -209,6 +209,7 @@ fn walk_py(
                                 handler_name: Some(name),
                                 language: "python".to_string(),
                                 framework: "flask/fastapi".to_string(),
+                                scope_name: String::new(),
                             });
                         }
                     }

--- a/src/lang/rust.rs
+++ b/src/lang/rust.rs
@@ -276,6 +276,7 @@ fn scan_children(
                                 handler_name: Some(name.to_string()),
                                 language: "rust".to_string(),
                                 framework: "actix/rocket".to_string(),
+                                scope_name: String::new(),
                             });
                         }
                     }

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -567,6 +567,7 @@ fn detect_express_call(
                 handler_name,
                 language: "typescript".to_string(),
                 framework: "express".to_string(),
+                scope_name: String::new(),
             });
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -366,7 +366,8 @@ fn build_registry() -> Vec<ToolEntry> {
                     "path": p(),
                     "query": s("Natural-language description, e.g. 'validate user token'"),
                     "limit": i("Max results (default 10, max 50)"),
-                    "file": s("Optional file path substring to restrict scope")
+                    "file": s("Optional file path substring to restrict scope"),
+                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web")
                 }),
             ),
             handler: Box::new(|a, path| {
@@ -375,12 +376,31 @@ fn build_registry() -> Vec<ToolEntry> {
                     a.str_req("query", "ask")?,
                     a.uint_opt("limit"),
                     a.str_opt("file"),
+                    a.str_opt("scope"),
                 )
             }),
         },
         ToolEntry {
-            schema: schema("routes", d("routes"), json!({"path": p()})),
-            handler: Box::new(|_a, path| crate::engine::all_endpoints(path)),
+            schema: schema(
+                "routes",
+                d("routes"),
+                json!({
+                    "path": p(),
+                    "query": s("Optional path or handler substring to narrow endpoint results."),
+                    "method": s("Optional HTTP method filter."),
+                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web."),
+                    "limit": i("Maximum number of endpoints to return.")
+                }),
+            ),
+            handler: Box::new(|a, path| {
+                crate::engine::all_endpoints(
+                    path,
+                    a.str_opt("query"),
+                    a.str_opt("method"),
+                    a.str_opt("scope"),
+                    a.uint_opt("limit"),
+                )
+            }),
         },
         ToolEntry {
             schema: schema_req(
@@ -392,7 +412,8 @@ fn build_registry() -> Vec<ToolEntry> {
                     "query": s("Engineering question, issue text, or failing-test summary."),
                     "symbol": s("Optional symbol hint to bias the judgment toward a known name."),
                     "file": s("Optional file path substring to restrict the search surface."),
-                    "limit": i("Maximum number of candidate symbols to return (default 3, max 5).")
+                    "limit": i("Maximum number of candidate symbols to return (default 3, max 5)."),
+                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web.")
                 }),
             ),
             handler: Box::new(|a, path| {
@@ -402,6 +423,7 @@ fn build_registry() -> Vec<ToolEntry> {
                     a.str_opt("symbol"),
                     a.str_opt("file"),
                     a.uint_opt("limit"),
+                    a.str_opt("scope"),
                 )
             }),
         },
@@ -415,7 +437,8 @@ fn build_registry() -> Vec<ToolEntry> {
                     "endpoint": s("URL path substring for endpoint-impact mode."),
                     "method": s("Optional HTTP method filter for endpoint mode."),
                     "depth": i("Max caller/call-chain depth."),
-                    "include_source": b("Include handler source inline in endpoint mode.")
+                    "include_source": b("Include handler source inline in endpoint mode."),
+                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web.")
                 }),
             ),
             handler: Box::new(|a, path| {
@@ -426,6 +449,7 @@ fn build_registry() -> Vec<ToolEntry> {
                     a.str_opt("method"),
                     a.uint_opt("depth"),
                     a.bool_opt("include_source"),
+                    a.str_opt("scope"),
                 )
             }),
         },


### PR DESCRIPTION
## Summary
- make scope metadata and scope dependencies first-class in the baked index and persist them through SQLite
- use stored scope summaries and reverse dependency edges in bake/boot responses, read paths, and scoped invalidation
- extend mixed-repo coverage to generated/backend dependencies and add DB + util regressions for dependency-driven refresh

## Testing
- cargo fmt
- cargo test

Closes #176