### PR TITLE
refactor: split MCP and script workflow surfaces

### DIFF
--- a/src/engine/index.rs
+++ b/src/engine/index.rs
@@ -141,211 +141,264 @@ pub fn llm_workflows(
     let view = ResponseView::parse(view.as_deref())?;
     let compact_limit = limit.unwrap_or(DEFAULT_COMPACT_LIMIT);
     let cursor = parse_section_cursor(cursor.as_deref())?;
-    let payload = LlmWorkflowsPayload {
+    let payload = llm_workflows_payload();
+
+    if let Some(q) = query {
+        return render_llm_workflows_query(&payload, q);
+    }
+
+    if matches!(view, ResponseView::Compact) {
+        return render_llm_workflows_compact(&payload, view, compact_limit, cursor);
+    }
+
+    Ok(serde_json::to_string_pretty(&payload)?)
+}
+
+fn llm_workflows_payload() -> LlmWorkflowsPayload {
+    LlmWorkflowsPayload {
         tool: "llm_workflows",
         version: env!("CARGO_PKG_VERSION"),
         workflows: workflow_catalog(),
         decision_map: decision_map(),
-        antipatterns: vec![
-            "grep to count callers: overcounts — hits comments, docs, string literals, partial names. Use impact(symbol=...).",
-            "grep to find a definition: returns all files containing the string, not the canonical definition. Use inspect(name=...).",
-            "reading raw source to determine visibility: pub/pub(crate)/nothing requires inference and is error-prone. Use inspect(name=...) — visibility is structured.",
-            "inferring module path from file path: conventions vary by language and project. Use inspect(name=...) — module_path is authoritative.",
-            "str.replace to rename: corrupts partial matches (e.g. renaming is_match also renames is_match_candidate). Use change(action=rename).",
-            "deleting a function without checking callers: leaves the codebase broken. Use impact(symbol=...) first, then change(action=delete).",
-            "grep to list methods of a struct: returns all fn definitions in the file, not grouped by type. Use inspect(file=...) and filter the outlined functions by parent_type.",
-            "grep to find trait implementors: matches impl blocks loosely, misses generic impls. Use inspect(name=...) — implementors are structured on trait matches.",
-            "reading struct source to get field types: works but is unstructured. Use inspect(name=..., include_source=true) — fields stay parsed and typed.",
-            "using raw editor-style writes to modify a function body: line numbers drift after edits, no reindex, no syntax check. Use change(action=edit) so the write resolves through the index and auto-reindexes.",
-            "scraping human-oriented write rejection text to decide what to retry: brittle and lossy. Use the structured guard_failure payload first (operation, phase, retryable, files, errors), then use next_hint only as fallback guidance.",
-            "calling multiple tools sequentially and combining their outputs manually: use script when you need to loop over tool output, filter arrays, cross-reference categories, or reduce across N items. One script call replaces N round-trips and returns a single structured result.",
-        ],
+        antipatterns: llm_workflow_antipatterns(),
         metapatterns: metapattern_catalog(),
+    }
+}
+
+fn llm_workflow_antipatterns() -> Vec<&'static str> {
+    vec![
+        "grep to count callers: overcounts — hits comments, docs, string literals, partial names. Use impact(symbol=...).",
+        "grep to find a definition: returns all files containing the string, not the canonical definition. Use inspect(name=...).",
+        "reading raw source to determine visibility: pub/pub(crate)/nothing requires inference and is error-prone. Use inspect(name=...) — visibility is structured.",
+        "inferring module path from file path: conventions vary by language and project. Use inspect(name=...) — module_path is authoritative.",
+        "str.replace to rename: corrupts partial matches (e.g. renaming is_match also renames is_match_candidate). Use change(action=rename).",
+        "deleting a function without checking callers: leaves the codebase broken. Use impact(symbol=...) first, then change(action=delete).",
+        "grep to list methods of a struct: returns all fn definitions in the file, not grouped by type. Use inspect(file=...) and filter the outlined functions by parent_type.",
+        "grep to find trait implementors: matches impl blocks loosely, misses generic impls. Use inspect(name=...) — implementors are structured on trait matches.",
+        "reading struct source to get field types: works but is unstructured. Use inspect(name=..., include_source=true) — fields stay parsed and typed.",
+        "using raw editor-style writes to modify a function body: line numbers drift after edits, no reindex, no syntax check. Use change(action=edit) so the write resolves through the index and auto-reindexes.",
+        "scraping human-oriented write rejection text to decide what to retry: brittle and lossy. Use the structured guard_failure payload first (operation, phase, retryable, files, errors), then use next_hint only as fallback guidance.",
+        "calling multiple tools sequentially and combining their outputs manually: use script when you need to loop over tool output, filter arrays, cross-reference categories, or reduce across N items. One script call replaces N round-trips and returns a single structured result.",
+    ]
+}
+
+fn workflow_matches(payload: &LlmWorkflowsPayload, words: &[&str]) -> Vec<WorkflowQueryMatch> {
+    let mut matches = Vec::new();
+    for workflow in &payload.workflows {
+        let text = format!(
+            "{} {} {}",
+            workflow.name,
+            workflow.description,
+            workflow
+                .steps
+                .iter()
+                .map(|step| format!("{} {}", step.tool, step.hint))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        let score = query_score(&text, words);
+        if score > 0 {
+            matches.push(WorkflowQueryMatch {
+                kind: "workflow",
+                score,
+                item: serde_json::json!({
+                    "name": workflow.name,
+                    "description": workflow.description,
+                    "steps": workflow.steps.iter().map(|step| serde_json::json!({
+                        "tool": step.tool,
+                        "hint": step.hint,
+                    })).collect::<Vec<_>>(),
+                }),
+            });
+        }
+    }
+    matches
+}
+
+fn decision_matches(payload: &LlmWorkflowsPayload, words: &[&str]) -> Vec<WorkflowQueryMatch> {
+    let mut matches = Vec::new();
+    for decision in &payload.decision_map {
+        let text = format!(
+            "{} {} {} {}",
+            decision.question, decision.right_tool, decision.right_field, decision.wrong_because
+        );
+        let score = query_score(&text, words);
+        if score > 0 {
+            matches.push(WorkflowQueryMatch {
+                kind: "decision",
+                score,
+                item: serde_json::json!({
+                    "question": decision.question,
+                    "right_tool": decision.right_tool,
+                    "right_field": decision.right_field,
+                }),
+            });
+        }
+    }
+    matches
+}
+
+fn antipattern_matches(payload: &LlmWorkflowsPayload, words: &[&str]) -> Vec<WorkflowQueryMatch> {
+    let mut matches = Vec::new();
+    for antipattern in &payload.antipatterns {
+        let score = query_score(antipattern, words);
+        if score > 0 {
+            matches.push(WorkflowQueryMatch {
+                kind: "antipattern",
+                score,
+                item: serde_json::json!({ "text": antipattern }),
+            });
+        }
+    }
+    matches
+}
+
+fn metapattern_matches(payload: &LlmWorkflowsPayload, words: &[&str]) -> Vec<WorkflowQueryMatch> {
+    let mut matches = Vec::new();
+    for metapattern in &payload.metapatterns {
+        let text = format!("{} {}", metapattern.shape, metapattern.when);
+        let score = query_score(&text, words);
+        if score > 0 {
+            matches.push(WorkflowQueryMatch {
+                kind: "metapattern",
+                score,
+                item: serde_json::json!({
+                    "shape": metapattern.shape,
+                    "when": metapattern.when,
+                }),
+            });
+        }
+    }
+    matches
+}
+
+fn render_llm_workflows_query(payload: &LlmWorkflowsPayload, query: String) -> Result<String> {
+    let words: Vec<&str> = query.split_whitespace().collect();
+    let mut matches = workflow_matches(payload, &words);
+    matches.extend(decision_matches(payload, &words));
+    matches.extend(antipattern_matches(payload, &words));
+    matches.extend(metapattern_matches(payload, &words));
+    matches.sort_by(|a, b| b.score.cmp(&a.score));
+    matches.truncate(10);
+
+    let result = LlmWorkflowsQueryPayload {
+        tool: payload.tool,
+        version: payload.version,
+        query,
+        matches,
     };
+    Ok(serde_json::to_string_pretty(&result)?)
+}
 
-    // ── query mode ────────────────────────────────────────────────────────────
-    if let Some(q) = query {
-        let words: Vec<&str> = q.split_whitespace().collect();
-        let mut matches: Vec<WorkflowQueryMatch> = Vec::new();
+fn compact_workflow_items(payload: &LlmWorkflowsPayload) -> Vec<serde_json::Value> {
+    payload
+        .workflows
+        .iter()
+        .map(|workflow| {
+            serde_json::json!({
+                "name": workflow.name,
+                "description": workflow.description,
+                "steps": workflow.steps.len(),
+                "first_tool": workflow.steps.first().map(|step| step.tool),
+            })
+        })
+        .collect()
+}
 
-        for wf in &payload.workflows {
-            let text = format!(
-                "{} {} {}",
-                wf.name,
-                wf.description,
-                wf.steps
-                    .iter()
-                    .map(|s| format!("{} {}", s.tool, s.hint))
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            );
-            let score = query_score(&text, &words);
-            if score > 0 {
-                matches.push(WorkflowQueryMatch {
-                    kind: "workflow",
-                    score,
-                    item: serde_json::json!({
-                        "name": wf.name,
-                        "description": wf.description,
-                        "steps": wf.steps.iter().map(|s| serde_json::json!({
-                            "tool": s.tool,
-                            "hint": s.hint,
-                        })).collect::<Vec<_>>(),
-                    }),
-                });
-            }
-        }
+fn compact_decision_items(payload: &LlmWorkflowsPayload) -> Vec<serde_json::Value> {
+    payload
+        .decision_map
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "question": entry.question,
+                "right_tool": entry.right_tool,
+                "right_field": entry.right_field,
+            })
+        })
+        .collect()
+}
 
-        for d in &payload.decision_map {
-            let text = format!(
-                "{} {} {} {}",
-                d.question, d.right_tool, d.right_field, d.wrong_because
-            );
-            let score = query_score(&text, &words);
-            if score > 0 {
-                matches.push(WorkflowQueryMatch {
-                    kind: "decision",
-                    score,
-                    item: serde_json::json!({
-                        "question": d.question,
-                        "right_tool": d.right_tool,
-                        "right_field": d.right_field,
-                    }),
-                });
-            }
-        }
+fn compact_antipattern_items(payload: &LlmWorkflowsPayload) -> Vec<serde_json::Value> {
+    payload
+        .antipatterns
+        .iter()
+        .map(|entry| serde_json::json!({ "text": entry }))
+        .collect()
+}
 
-        for ap in &payload.antipatterns {
-            let score = query_score(ap, &words);
-            if score > 0 {
-                matches.push(WorkflowQueryMatch {
-                    kind: "antipattern",
-                    score,
-                    item: serde_json::json!({ "text": ap }),
-                });
-            }
-        }
+fn compact_metapattern_items(payload: &LlmWorkflowsPayload) -> Vec<serde_json::Value> {
+    payload
+        .metapatterns
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "shape": entry.shape,
+                "when": entry.when,
+                "instances": entry.instances.len(),
+            })
+        })
+        .collect()
+}
 
-        for mp in &payload.metapatterns {
-            let text = format!("{} {}", mp.shape, mp.when);
-            let score = query_score(&text, &words);
-            if score > 0 {
-                matches.push(WorkflowQueryMatch {
-                    kind: "metapattern",
-                    score,
-                    item: serde_json::json!({
-                        "shape": mp.shape,
-                        "when": mp.when,
-                    }),
-                });
-            }
-        }
+fn render_llm_workflows_compact(
+    payload: &LlmWorkflowsPayload,
+    view: ResponseView,
+    compact_limit: usize,
+    cursor: Option<(String, usize)>,
+) -> Result<String> {
+    let cursor_ref = cursor
+        .as_ref()
+        .map(|(section, offset)| (section.as_str(), *offset));
+    let sections = vec![
+        build_compact_section(
+            "workflows",
+            compact_workflow_items(payload),
+            compact_limit,
+            cursor_ref,
+        ),
+        build_compact_section(
+            "decision_map",
+            compact_decision_items(payload),
+            compact_limit,
+            cursor_ref,
+        ),
+        build_compact_section(
+            "antipatterns",
+            compact_antipattern_items(payload),
+            compact_limit,
+            cursor_ref,
+        ),
+        build_compact_section(
+            "metapatterns",
+            compact_metapattern_items(payload),
+            compact_limit,
+            cursor_ref,
+        ),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
 
-        matches.sort_by(|a, b| b.score.cmp(&a.score));
-        matches.truncate(10);
-
-        let result = LlmWorkflowsQueryPayload {
-            tool: payload.tool,
-            version: payload.version,
-            query: q,
-            matches,
-        };
-        return Ok(serde_json::to_string_pretty(&result)?);
-    }
-
-    // ── compact mode ─────────────────────────────────────────────────────────
-    if matches!(view, ResponseView::Compact) {
-        let cursor_ref = cursor
-            .as_ref()
-            .map(|(section, offset)| (section.as_str(), *offset));
-        let sections = vec![
-            build_compact_section(
-                "workflows",
-                payload
-                    .workflows
-                    .iter()
-                    .map(|workflow| {
-                        serde_json::json!({
-                            "name": workflow.name,
-                            "description": workflow.description,
-                            "steps": workflow.steps.len(),
-                            "first_tool": workflow.steps.first().map(|step| step.tool),
-                        })
-                    })
-                    .collect(),
-                compact_limit,
-                cursor_ref,
-            ),
-            build_compact_section(
-                "decision_map",
-                payload
-                    .decision_map
-                    .iter()
-                    .map(|entry| {
-                        serde_json::json!({
-                            "question": entry.question,
-                            "right_tool": entry.right_tool,
-                            "right_field": entry.right_field,
-                        })
-                    })
-                    .collect(),
-                compact_limit,
-                cursor_ref,
-            ),
-            build_compact_section(
-                "antipatterns",
-                payload
-                    .antipatterns
-                    .iter()
-                    .map(|entry| serde_json::json!({ "text": entry }))
-                    .collect(),
-                compact_limit,
-                cursor_ref,
-            ),
-            build_compact_section(
-                "metapatterns",
-                payload
-                    .metapatterns
-                    .iter()
-                    .map(|entry| {
-                        serde_json::json!({
-                            "shape": entry.shape,
-                            "when": entry.when,
-                            "instances": entry.instances.len(),
-                        })
-                    })
-                    .collect(),
-                compact_limit,
-                cursor_ref,
-            ),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        let compact = LlmWorkflowsCompactPayload {
-            tool: payload.tool,
-            version: payload.version,
-            view: view.as_str(),
-            summary: format!(
-                "{} workflows, {} decision entries, {} antipatterns, {} metapatterns",
-                payload.workflows.len(),
-                payload.decision_map.len(),
-                payload.antipatterns.len(),
-                payload.metapatterns.len(),
-            ),
-            sections,
-            detail_hints: vec![
-                "use --view raw for the full reference catalog",
-                "use --cursor <section>:<offset> to page one section forward",
-                "use llm_instructions first and call llm_workflows only when you need deeper guidance",
-            ],
-        };
-        return Ok(serde_json::to_string_pretty(&compact)?);
-    }
-
-    let json = serde_json::to_string_pretty(&payload)?;
-    Ok(json)
+    let compact = LlmWorkflowsCompactPayload {
+        tool: payload.tool,
+        version: payload.version,
+        view: view.as_str(),
+        summary: format!(
+            "{} workflows, {} decision entries, {} antipatterns, {} metapatterns",
+            payload.workflows.len(),
+            payload.decision_map.len(),
+            payload.antipatterns.len(),
+            payload.metapatterns.len(),
+        ),
+        sections,
+        detail_hints: vec![
+            "use --view raw for the full reference catalog",
+            "use --cursor <section>:<offset> to page one section forward",
+            "use llm_instructions first and call llm_workflows only when you need deeper guidance",
+        ],
+    };
+    Ok(serde_json::to_string_pretty(&compact)?)
 }
 
 /// Score a text against a set of query words (case-insensitive word overlap).

--- a/src/engine/script.rs
+++ b/src/engine/script.rs
@@ -105,57 +105,53 @@ fn parse_edits(args: &JsonMap<String, Value>) -> Result<Option<Vec<crate::engine
     Ok(Some(edits))
 }
 
-pub fn run_script(path: Option<String>, code: String) -> Result<String> {
-    let root = resolve_project_root(path)?;
-    let r = root.to_string_lossy().into_owned();
-
-    let mut engine = Engine::new();
-
-    // --- Bootstrap + discovery ---
+fn register_bootstrap_and_discovery(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("boot", move || -> Dynamic {
             call_to_dynamic(crate::engine::llm_instructions(Some(rc.clone())))
         });
     }
     {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("index", move || -> Dynamic {
             call_to_dynamic(crate::engine::bake(Some(rc.clone())))
         });
     }
-    {
-        engine.register_fn("help", move |name: String| -> Dynamic {
-            call_to_dynamic(crate::engine::tool_help(name))
-        });
-    }
+    engine.register_fn("help", move |name: String| -> Dynamic {
+        call_to_dynamic(crate::engine::tool_help(name))
+    });
+}
 
-    // --- Task-shaped read tools ---
+fn register_inspect_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
+    engine.register_fn("inspect", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::inspect(
+                Some(root.clone()),
+                str_opt(&args, "name"),
+                str_opt(&args, "file"),
+                uint_opt(&args, "start_line").map(|v| v as u32),
+                uint_opt(&args, "end_line").map(|v| v as u32),
+                bool_opt(&args, "include_source"),
+                bool_opt(&args, "include_summaries"),
+                uint_opt(&args, "limit"),
+                bool_opt(&args, "stdlib"),
+                bool_opt(&args, "signature_only"),
+                bool_opt(&args, "type_only"),
+                str_opt(&args, "depth"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_search_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
-        engine.register_fn("inspect", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::inspect(
-                    Some(rc.clone()),
-                    str_opt(&args, "name"),
-                    str_opt(&args, "file"),
-                    uint_opt(&args, "start_line").map(|v| v as u32),
-                    uint_opt(&args, "end_line").map(|v| v as u32),
-                    bool_opt(&args, "include_source"),
-                    bool_opt(&args, "include_summaries"),
-                    uint_opt(&args, "limit"),
-                    bool_opt(&args, "stdlib"),
-                    bool_opt(&args, "signature_only"),
-                    bool_opt(&args, "type_only"),
-                    str_opt(&args, "depth"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("search", move |query: String| -> Dynamic {
             call_to_dynamic(crate::engine::supersearch(
                 Some(rc.clone()),
@@ -168,41 +164,42 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
             ))
         });
     }
-    {
-        let rc = r.clone();
-        engine.register_fn("search", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                const MODES: &[&str] = &["all", "call", "assign", "return"];
-                let args = json_args(args)?;
-                let raw_pattern = str_opt(&args, "pattern");
-                let query = if let Some(query) = str_opt(&args, "query") {
-                    query
-                } else if let Some(ref pattern) = raw_pattern {
-                    if MODES.contains(&pattern.as_str()) {
-                        return Err(anyhow!("Missing required 'query' argument for search"));
-                    }
-                    pattern.clone()
-                } else {
+    engine.register_fn("search", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            const MODES: &[&str] = &["all", "call", "assign", "return"];
+            let args = json_args(args)?;
+            let raw_pattern = str_opt(&args, "pattern");
+            let query = if let Some(query) = str_opt(&args, "query") {
+                query
+            } else if let Some(ref pattern) = raw_pattern {
+                if MODES.contains(&pattern.as_str()) {
                     return Err(anyhow!("Missing required 'query' argument for search"));
-                };
-                let pattern = raw_pattern
-                    .filter(|p| MODES.contains(&p.as_str()))
-                    .unwrap_or_else(|| "all".to_string());
-                crate::engine::supersearch(
-                    Some(rc.clone()),
-                    query,
-                    str_opt(&args, "context").unwrap_or_else(|| "all".to_string()),
-                    pattern,
-                    bool_opt(&args, "exclude_tests"),
-                    str_opt(&args, "file"),
-                    uint_opt(&args, "limit"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
+                }
+                pattern.clone()
+            } else {
+                return Err(anyhow!("Missing required 'query' argument for search"));
+            };
+            let pattern = raw_pattern
+                .filter(|p| MODES.contains(&p.as_str()))
+                .unwrap_or_else(|| "all".to_string());
+            crate::engine::supersearch(
+                Some(root.clone()),
+                query,
+                str_opt(&args, "context").unwrap_or_else(|| "all".to_string()),
+                pattern,
+                bool_opt(&args, "exclude_tests"),
+                str_opt(&args, "file"),
+                uint_opt(&args, "limit"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_ask_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("ask", move |query: String| -> Dynamic {
             call_to_dynamic(crate::engine::semantic_search(
                 Some(rc.clone()),
@@ -213,44 +210,45 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
             ))
         });
     }
+    engine.register_fn("ask", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::semantic_search(
+                Some(root.clone()),
+                str_opt(&args, "query")
+                    .ok_or_else(|| anyhow!("Missing required 'query' argument for ask"))?,
+                uint_opt(&args, "limit"),
+                str_opt(&args, "file"),
+                str_opt(&args, "scope"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_judge_change_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
+    engine.register_fn("judge_change", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::judge_change(
+                Some(root.clone()),
+                str_opt(&args, "query")
+                    .ok_or_else(|| anyhow!("Missing required 'query' argument for judge_change"))?,
+                str_opt(&args, "symbol"),
+                str_opt(&args, "file"),
+                uint_opt(&args, "limit"),
+                str_opt(&args, "scope"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_map_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
-        engine.register_fn("ask", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::semantic_search(
-                    Some(rc.clone()),
-                    str_opt(&args, "query")
-                        .ok_or_else(|| anyhow!("Missing required 'query' argument for ask"))?,
-                    uint_opt(&args, "limit"),
-                    str_opt(&args, "file"),
-                    str_opt(&args, "scope"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
-        engine.register_fn("judge_change", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::judge_change(
-                    Some(rc.clone()),
-                    str_opt(&args, "query").ok_or_else(|| {
-                        anyhow!("Missing required 'query' argument for judge_change")
-                    })?,
-                    str_opt(&args, "symbol"),
-                    str_opt(&args, "file"),
-                    uint_opt(&args, "limit"),
-                    str_opt(&args, "scope"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("map", move |intent: String| -> Dynamic {
             call_to_dynamic(crate::engine::architecture_map(
                 Some(rc.clone()),
@@ -259,22 +257,23 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
             ))
         });
     }
+    engine.register_fn("map", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::architecture_map(
+                Some(root.clone()),
+                str_opt(&args, "intent"),
+                uint_opt(&args, "limit"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_routes_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
-        engine.register_fn("map", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::architecture_map(
-                    Some(rc.clone()),
-                    str_opt(&args, "intent"),
-                    uint_opt(&args, "limit"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("routes", move || -> Dynamic {
             call_to_dynamic(crate::engine::all_endpoints(
                 Some(rc.clone()),
@@ -285,42 +284,44 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
             ))
         });
     }
+    engine.register_fn("routes", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::all_endpoints(
+                Some(root.clone()),
+                str_opt(&args, "query"),
+                str_opt(&args, "method"),
+                str_opt(&args, "scope"),
+                uint_opt(&args, "limit"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_impact_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
+    engine.register_fn("impact", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::impact(
+                Some(root.clone()),
+                str_opt(&args, "symbol"),
+                str_opt(&args, "endpoint"),
+                str_opt(&args, "method"),
+                uint_opt(&args, "depth"),
+                bool_opt(&args, "include_source"),
+                str_opt(&args, "scope"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn register_health_tool(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
     {
-        let rc = r.clone();
-        engine.register_fn("routes", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::all_endpoints(
-                    Some(rc.clone()),
-                    str_opt(&args, "query"),
-                    str_opt(&args, "method"),
-                    str_opt(&args, "scope"),
-                    uint_opt(&args, "limit"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
-        engine.register_fn("impact", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::impact(
-                    Some(rc.clone()),
-                    str_opt(&args, "symbol"),
-                    str_opt(&args, "endpoint"),
-                    str_opt(&args, "method"),
-                    uint_opt(&args, "depth"),
-                    bool_opt(&args, "include_source"),
-                    str_opt(&args, "scope"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
-    {
-        let rc = r.clone();
+        let rc = root.clone();
         engine.register_fn("health", move || -> Dynamic {
             call_to_dynamic(crate::engine::health(
                 Some(rc.clone()),
@@ -331,62 +332,82 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
             ))
         });
     }
-    {
-        let rc = r.clone();
-        engine.register_fn("health", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::health(
-                    Some(rc.clone()),
-                    uint_opt(&args, "top"),
-                    str_opt(&args, "view"),
-                    uint_opt(&args, "limit"),
-                    str_opt(&args, "cursor"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
+    engine.register_fn("health", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::health(
+                Some(root.clone()),
+                uint_opt(&args, "top"),
+                str_opt(&args, "view"),
+                uint_opt(&args, "limit"),
+                str_opt(&args, "cursor"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
 
-    // --- Task-shaped write tool ---
-    {
-        let rc = r.clone();
-        engine.register_fn("change", move |args: RhaiMap| -> Dynamic {
-            let res = (|| {
-                let args = json_args(args)?;
-                crate::engine::change(
-                    Some(rc.clone()),
-                    str_opt(&args, "action")
-                        .ok_or_else(|| anyhow!("Missing required 'action' argument for change"))?,
-                    str_opt(&args, "name"),
-                    str_opt(&args, "file"),
-                    uint_opt(&args, "start_line").map(|v| v as u32),
-                    uint_opt(&args, "end_line").map(|v| v as u32),
-                    str_opt(&args, "new_content"),
-                    str_opt(&args, "old_string"),
-                    str_opt(&args, "new_string"),
-                    uint_opt(&args, "match_index"),
-                    parse_edits(&args)?,
-                    str_opt(&args, "new_name"),
-                    str_opt(&args, "to_file"),
-                    bool_opt(&args, "force"),
-                    str_opt(&args, "function_name"),
-                    str_opt(&args, "entity_type"),
-                    str_opt(&args, "after_symbol"),
-                    str_opt(&args, "language"),
-                    parse_params(args.get("params")),
-                    str_opt(&args, "returns"),
-                    str_opt(&args, "on"),
-                )
-            })();
-            call_to_dynamic(res)
-        });
-    }
+fn register_read_tools(engine: &mut Engine, root: &str) {
+    register_inspect_tool(engine, root);
+    register_search_tool(engine, root);
+    register_ask_tool(engine, root);
+    register_judge_change_tool(engine, root);
+    register_map_tool(engine, root);
+    register_routes_tool(engine, root);
+    register_impact_tool(engine, root);
+    register_health_tool(engine, root);
+}
 
-    let result: Dynamic = engine
+fn register_write_tools(engine: &mut Engine, root: &str) {
+    let root = root.to_string();
+    let rc = root.clone();
+    engine.register_fn("change", move |args: RhaiMap| -> Dynamic {
+        let res = (|| {
+            let args = json_args(args)?;
+            crate::engine::change(
+                Some(rc.clone()),
+                str_opt(&args, "action")
+                    .ok_or_else(|| anyhow!("Missing required 'action' argument for change"))?,
+                str_opt(&args, "name"),
+                str_opt(&args, "file"),
+                uint_opt(&args, "start_line").map(|v| v as u32),
+                uint_opt(&args, "end_line").map(|v| v as u32),
+                str_opt(&args, "new_content"),
+                str_opt(&args, "old_string"),
+                str_opt(&args, "new_string"),
+                uint_opt(&args, "match_index"),
+                parse_edits(&args)?,
+                str_opt(&args, "new_name"),
+                str_opt(&args, "to_file"),
+                bool_opt(&args, "force"),
+                str_opt(&args, "function_name"),
+                str_opt(&args, "entity_type"),
+                str_opt(&args, "after_symbol"),
+                str_opt(&args, "language"),
+                parse_params(args.get("params")),
+                str_opt(&args, "returns"),
+                str_opt(&args, "on"),
+            )
+        })();
+        call_to_dynamic(res)
+    });
+}
+
+fn build_script_engine(root: &str) -> Engine {
+    let mut engine = Engine::new();
+    register_bootstrap_and_discovery(&mut engine, root);
+    register_read_tools(&mut engine, root);
+    register_write_tools(&mut engine, root);
+    engine
+}
+
+fn execute_script(engine: &Engine, code: &str) -> Result<Dynamic> {
+    engine
         .eval(&code)
-        .map_err(|e| anyhow::anyhow!("Script error: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Script error: {}", e))
+}
 
+fn render_script_result(root: &std::path::Path, result: Dynamic) -> Result<String> {
     let json_val: serde_json::Value = rhai::serde::from_dynamic(&result)
         .map_err(|e| anyhow::anyhow!("Failed to serialize result: {}", e))?;
 
@@ -398,6 +419,14 @@ pub fn run_script(path: Option<String>, code: String) -> Result<String> {
     });
 
     Ok(serde_json::to_string_pretty(&payload)?)
+}
+
+pub fn run_script(path: Option<String>, code: String) -> Result<String> {
+    let root = resolve_project_root(path)?;
+    let root_str = root.to_string_lossy().into_owned();
+    let engine = build_script_engine(&root_str);
+    let result = execute_script(&engine, &code)?;
+    render_script_result(&root, result)
 }
 
 #[cfg(test)]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::OnceLock;
 use tokio::io::{self, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
@@ -223,275 +224,388 @@ impl ToolEntry {
     }
 }
 
-fn build_registry() -> Vec<ToolEntry> {
-    fn s(desc: &str) -> Value {
-        json!({"type": "string", "description": desc})
+fn string_prop(desc: &str) -> Value {
+    json!({"type": "string", "description": desc})
+}
+
+fn int_prop(desc: &str) -> Value {
+    json!({"type": "integer", "description": desc})
+}
+
+fn bool_prop(desc: &str) -> Value {
+    json!({"type": "boolean", "description": desc})
+}
+
+fn path_prop() -> Value {
+    string_prop("Optional path to project directory")
+}
+
+fn schema(name: &str, desc: &str, props: Value) -> Value {
+    json!({"name": name, "description": desc, "inputSchema": {"type": "object", "properties": props}})
+}
+
+fn schema_req(name: &str, desc: &str, req: &[&str], props: Value) -> Value {
+    json!({"name": name, "description": desc, "inputSchema": {"type": "object", "required": req, "properties": props}})
+}
+
+fn tool_catalog_map() -> HashMap<&'static str, &'static str> {
+    crate::engine::tool_catalog()
+        .into_iter()
+        .map(|t| (t.name, t.description))
+        .collect()
+}
+
+fn tool_desc<'a>(catalog: &'a HashMap<&'static str, &'static str>, name: &'static str) -> &'a str {
+    catalog.get(name).copied().unwrap_or(name)
+}
+
+fn tool_entry(
+    schema: Value,
+    handler: impl Fn(Args, Option<String>) -> Result<String> + Send + Sync + 'static,
+) -> ToolEntry {
+    ToolEntry {
+        schema,
+        handler: Box::new(handler),
     }
-    fn i(desc: &str) -> Value {
-        json!({"type": "integer", "description": desc})
-    }
-    fn b(desc: &str) -> Value {
-        json!({"type": "boolean", "description": desc})
-    }
-    fn p() -> Value {
-        s("Optional path to project directory")
+}
+
+fn search_query_and_pattern(args: &Args) -> Result<(String, String)> {
+    const MODES: &[&str] = &["all", "call", "assign", "return"];
+    let raw_pattern = args.str_opt("pattern");
+    let query = if let Some(query) = args.str_opt("query") {
+        query
+    } else if let Some(ref pattern) = raw_pattern {
+        if !MODES.contains(&pattern.as_str()) {
+            pattern.clone()
+        } else {
+            return Err(anyhow::anyhow!(
+                "Missing required 'query' argument for search"
+            ));
+        }
+    } else {
+        return Err(anyhow::anyhow!(
+            "Missing required 'query' argument for search"
+        ));
+    };
+    let pattern = raw_pattern
+        .filter(|pattern| MODES.contains(&pattern.as_str()))
+        .unwrap_or_else(|| "all".to_string());
+    Ok((query, pattern))
+}
+
+fn parse_change_edits(args: &Args) -> Result<Option<Vec<crate::engine::PatchEdit>>> {
+    let items = match args.0.get("edits").and_then(|value| value.as_array()) {
+        Some(items) => items,
+        None => return Ok(None),
+    };
+
+    let mut edits = Vec::with_capacity(items.len());
+    for item in items {
+        let file = item
+            .get("file")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Each change.edits item must have a 'file' field"))?
+            .to_string();
+        let byte_start = item
+            .get("byte_start")
+            .and_then(|value| value.as_u64())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Each change.edits item must have a 'byte_start' field")
+            })? as usize;
+        let byte_end = item
+            .get("byte_end")
+            .and_then(|value| value.as_u64())
+            .ok_or_else(|| anyhow::anyhow!("Each change.edits item must have a 'byte_end' field"))?
+            as usize;
+        let new_content = item
+            .get("new_content")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Each change.edits item must have a 'new_content' field")
+            })?
+            .to_string();
+        edits.push(crate::engine::PatchEdit {
+            file,
+            byte_start,
+            byte_end,
+            new_content,
+        });
     }
 
-    let catalog: std::collections::HashMap<&'static str, &'static str> =
-        crate::engine::tool_catalog()
-            .into_iter()
-            .map(|t| (t.name, t.description))
-            .collect();
-    let d = |name: &'static str| -> &'static str { catalog.get(name).copied().unwrap_or(name) };
+    Ok(Some(edits))
+}
 
-    fn schema(name: &str, desc: &str, props: Value) -> Value {
-        json!({"name": name, "description": desc, "inputSchema": {"type": "object", "properties": props}})
-    }
-    fn schema_req(name: &str, desc: &str, req: &[&str], props: Value) -> Value {
-        json!({"name": name, "description": desc, "inputSchema": {"type": "object", "required": req, "properties": props}})
-    }
+fn handle_search_tool(args: Args, path: Option<String>) -> Result<String> {
+    let (query, pattern) = search_query_and_pattern(&args)?;
+    crate::engine::supersearch(
+        path,
+        query,
+        args.str_opt("context").unwrap_or_else(|| "all".to_string()),
+        pattern,
+        args.bool_opt("exclude_tests"),
+        args.str_opt("file"),
+        args.uint_opt("limit"),
+    )
+}
 
+fn handle_change_tool(args: Args, path: Option<String>) -> Result<String> {
+    let edits = parse_change_edits(&args)?;
+    crate::engine::change(
+        path,
+        args.str_req("action", "change")?,
+        args.str_opt("name"),
+        args.str_opt("file"),
+        args.uint_opt("start_line").map(|value| value as u32),
+        args.uint_opt("end_line").map(|value| value as u32),
+        args.str_opt("new_content"),
+        args.str_opt("old_string"),
+        args.str_opt("new_string"),
+        args.uint_opt("match_index"),
+        edits,
+        args.str_opt("new_name"),
+        args.str_opt("to_file"),
+        args.bool_opt("force"),
+        args.str_opt("function_name"),
+        args.str_opt("entity_type"),
+        args.str_opt("after_symbol"),
+        args.str_opt("language"),
+        parse_params(args.0.get("params")),
+        args.str_opt("returns"),
+        args.str_opt("on"),
+    )
+}
+
+fn bootstrap_entries(catalog: &HashMap<&'static str, &'static str>) -> Vec<ToolEntry> {
     vec![
-        // ── bootstrap ────────────────────────────────────────────────────────
-        ToolEntry {
-            schema: schema("boot", d("boot"), json!({"path": p()})),
-            handler: Box::new(|_a, path| crate::engine::llm_instructions(path)),
-        },
-        ToolEntry {
-            schema: schema("index", d("index"), json!({"path": p()})),
-            handler: Box::new(|_a, path| crate::engine::bake(path)),
-        },
-        ToolEntry {
-            schema: schema(
+        tool_entry(
+            schema(
+                "boot",
+                tool_desc(catalog, "boot"),
+                json!({"path": path_prop()}),
+            ),
+            |_args, path| crate::engine::llm_instructions(path),
+        ),
+        tool_entry(
+            schema(
+                "index",
+                tool_desc(catalog, "index"),
+                json!({"path": path_prop()}),
+            ),
+            |_args, path| crate::engine::bake(path),
+        ),
+        tool_entry(
+            schema(
                 "inspect",
-                d("inspect"),
+                tool_desc(catalog, "inspect"),
                 json!({
-                    "path": p(),
-                    "name": s("Function name for symbol mode."),
-                    "file": s("File path for file or line-range mode."),
-                    "start_line": i("1-based start line for line-range mode."),
-                    "end_line": i("1-based end line for line-range mode."),
-                    "include_source": b("Include function body in symbol mode."),
-                    "signature_only": b("Return declaration/signature text only in symbol mode."),
-                    "type_only": b("Return a type surface instead of generic symbol matches."),
-                    "include_summaries": b("Include summaries in file mode."),
-                    "depth": s("File structure depth in file mode: 1, 2, or all."),
-                    "limit": i("Maximum number of symbol matches."),
-                    "stdlib": b("Include stdlib matches in symbol mode.")
+                    "path": path_prop(),
+                    "name": string_prop("Function name for symbol mode."),
+                    "file": string_prop("File path for file or line-range mode."),
+                    "start_line": int_prop("1-based start line for line-range mode."),
+                    "end_line": int_prop("1-based end line for line-range mode."),
+                    "include_source": bool_prop("Include function body in symbol mode."),
+                    "signature_only": bool_prop("Return declaration/signature text only in symbol mode."),
+                    "type_only": bool_prop("Return a type surface instead of generic symbol matches."),
+                    "include_summaries": bool_prop("Include summaries in file mode."),
+                    "depth": string_prop("File structure depth in file mode: 1, 2, or all."),
+                    "limit": int_prop("Maximum number of symbol matches."),
+                    "stdlib": bool_prop("Include stdlib matches in symbol mode.")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::inspect(
                     path,
-                    a.str_opt("name"),
-                    a.str_opt("file"),
-                    a.uint_opt("start_line").map(|v| v as u32),
-                    a.uint_opt("end_line").map(|v| v as u32),
-                    a.bool_opt("include_source"),
-                    a.bool_opt("include_summaries"),
-                    a.uint_opt("limit"),
-                    a.bool_opt("stdlib"),
-                    a.bool_opt("signature_only"),
-                    a.bool_opt("type_only"),
-                    a.str_opt("depth"),
+                    args.str_opt("name"),
+                    args.str_opt("file"),
+                    args.uint_opt("start_line").map(|value| value as u32),
+                    args.uint_opt("end_line").map(|value| value as u32),
+                    args.bool_opt("include_source"),
+                    args.bool_opt("include_summaries"),
+                    args.uint_opt("limit"),
+                    args.bool_opt("stdlib"),
+                    args.bool_opt("signature_only"),
+                    args.bool_opt("type_only"),
+                    args.str_opt("depth"),
                 )
-            }),
-        },
-        // ── read-indexed ─────────────────────────────────────────────────────
-        ToolEntry {
-            schema: schema(
+            },
+        ),
+    ]
+}
+
+fn read_indexed_entries(catalog: &HashMap<&'static str, &'static str>) -> Vec<ToolEntry> {
+    vec![
+        tool_entry(
+            schema(
                 "map",
-                d("map"),
+                tool_desc(catalog, "map"),
                 json!({
-                    "path": p(),
-                    "intent": s("Intent description, e.g. \"user handler\" or \"auth service\""),
-                    "limit": {"type": "integer", "description": "Max directories to return (default 100)."}
+                    "path": path_prop(),
+                    "intent": string_prop("Intent description, e.g. \"user handler\" or \"auth service\""),
+                    "limit": int_prop("Max directories to return (default 100).")
                 }),
             ),
-            handler: Box::new(|a, path| {
-                crate::engine::architecture_map(path, a.str_opt("intent"), a.uint_opt("limit"))
-            }),
-        },
-        ToolEntry {
-            schema: schema(
-                "search",
-                d("search"),
-                json!({
-                    "path": p(),
-                    "query": s("Search query text"),
-                    "context": s("Search context: all | strings | comments | identifiers"),
-                    "pattern": s("Pattern: all | call | assign | return"),
-                    "exclude_tests": b("Whether to exclude likely test files"),
-                    "file": s("Optional file path substring to restrict scope"),
-                    "limit": i("Max matches to return (default 200).")
-                }),
-            ),
-            handler: Box::new(|a, path| {
-                const MODES: &[&str] = &["all", "call", "assign", "return"];
-                let raw_pattern = a.str_opt("pattern");
-                let query = if let Some(q) = a.str_opt("query") {
-                    q
-                } else if let Some(ref p) = raw_pattern {
-                    if !MODES.contains(&p.as_str()) {
-                        p.clone()
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Missing required 'query' argument for search"
-                        ));
-                    }
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "Missing required 'query' argument for search"
-                    ));
-                };
-                let pattern = raw_pattern
-                    .filter(|p| MODES.contains(&p.as_str()))
-                    .unwrap_or_else(|| "all".to_string());
-                crate::engine::supersearch(
+            |args, path| {
+                crate::engine::architecture_map(
                     path,
-                    query,
-                    a.str_opt("context").unwrap_or_else(|| "all".to_string()),
-                    pattern,
-                    a.bool_opt("exclude_tests"),
-                    a.str_opt("file"),
-                    a.uint_opt("limit"),
+                    args.str_opt("intent"),
+                    args.uint_opt("limit"),
                 )
-            }),
-        },
-        ToolEntry {
-            schema: schema(
-                "ask",
-                d("ask"),
+            },
+        ),
+        tool_entry(
+            schema(
+                "search",
+                tool_desc(catalog, "search"),
                 json!({
-                    "path": p(),
-                    "query": s("Natural-language description, e.g. 'validate user token'"),
-                    "limit": i("Max results (default 10, max 50)"),
-                    "file": s("Optional file path substring to restrict scope"),
-                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web")
+                    "path": path_prop(),
+                    "query": string_prop("Search query text"),
+                    "context": string_prop("Search context: all | strings | comments | identifiers"),
+                    "pattern": string_prop("Pattern: all | call | assign | return"),
+                    "exclude_tests": bool_prop("Whether to exclude likely test files"),
+                    "file": string_prop("Optional file path substring to restrict scope"),
+                    "limit": int_prop("Max matches to return (default 200).")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            handle_search_tool,
+        ),
+        tool_entry(
+            schema(
+                "ask",
+                tool_desc(catalog, "ask"),
+                json!({
+                    "path": path_prop(),
+                    "query": string_prop("Natural-language description, e.g. 'validate user token'"),
+                    "limit": int_prop("Max results (default 10, max 50)"),
+                    "file": string_prop("Optional file path substring to restrict scope"),
+                    "scope": string_prop("Optional workspace/package/slice hint, e.g. backend or web")
+                }),
+            ),
+            |args, path| {
                 crate::engine::semantic_search(
                     path,
-                    a.str_req("query", "ask")?,
-                    a.uint_opt("limit"),
-                    a.str_opt("file"),
-                    a.str_opt("scope"),
+                    args.str_req("query", "ask")?,
+                    args.uint_opt("limit"),
+                    args.str_opt("file"),
+                    args.str_opt("scope"),
                 )
-            }),
-        },
-        ToolEntry {
-            schema: schema(
+            },
+        ),
+        tool_entry(
+            schema(
                 "routes",
-                d("routes"),
+                tool_desc(catalog, "routes"),
                 json!({
-                    "path": p(),
-                    "query": s("Optional path or handler substring to narrow endpoint results."),
-                    "method": s("Optional HTTP method filter."),
-                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web."),
-                    "limit": i("Maximum number of endpoints to return.")
+                    "path": path_prop(),
+                    "query": string_prop("Optional path or handler substring to narrow endpoint results."),
+                    "method": string_prop("Optional HTTP method filter."),
+                    "scope": string_prop("Optional workspace/package/slice hint, e.g. backend or web."),
+                    "limit": int_prop("Maximum number of endpoints to return.")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::all_endpoints(
                     path,
-                    a.str_opt("query"),
-                    a.str_opt("method"),
-                    a.str_opt("scope"),
-                    a.uint_opt("limit"),
+                    args.str_opt("query"),
+                    args.str_opt("method"),
+                    args.str_opt("scope"),
+                    args.uint_opt("limit"),
                 )
-            }),
-        },
-        ToolEntry {
-            schema: schema_req(
+            },
+        ),
+        tool_entry(
+            schema_req(
                 "judge_change",
-                d("judge_change"),
+                tool_desc(catalog, "judge_change"),
                 &["query"],
                 json!({
-                    "path": p(),
-                    "query": s("Engineering question, issue text, or failing-test summary."),
-                    "symbol": s("Optional symbol hint to bias the judgment toward a known name."),
-                    "file": s("Optional file path substring to restrict the search surface."),
-                    "limit": i("Maximum number of candidate symbols to return (default 3, max 5)."),
-                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web.")
+                    "path": path_prop(),
+                    "query": string_prop("Engineering question, issue text, or failing-test summary."),
+                    "symbol": string_prop("Optional symbol hint to bias the judgment toward a known name."),
+                    "file": string_prop("Optional file path substring to restrict the search surface."),
+                    "limit": int_prop("Maximum number of candidate symbols to return (default 3, max 5)."),
+                    "scope": string_prop("Optional workspace/package/slice hint, e.g. backend or web.")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::judge_change(
                     path,
-                    a.str_req("query", "judge_change")?,
-                    a.str_opt("symbol"),
-                    a.str_opt("file"),
-                    a.uint_opt("limit"),
-                    a.str_opt("scope"),
+                    args.str_req("query", "judge_change")?,
+                    args.str_opt("symbol"),
+                    args.str_opt("file"),
+                    args.uint_opt("limit"),
+                    args.str_opt("scope"),
                 )
-            }),
-        },
-        ToolEntry {
-            schema: schema(
+            },
+        ),
+        tool_entry(
+            schema(
                 "impact",
-                d("impact"),
+                tool_desc(catalog, "impact"),
                 json!({
-                    "path": p(),
-                    "symbol": s("Function name for symbol-impact mode."),
-                    "endpoint": s("URL path substring for endpoint-impact mode."),
-                    "method": s("Optional HTTP method filter for endpoint mode."),
-                    "depth": i("Max caller/call-chain depth."),
-                    "include_source": b("Include handler source inline in endpoint mode."),
-                    "scope": s("Optional workspace/package/slice hint, e.g. backend or web.")
+                    "path": path_prop(),
+                    "symbol": string_prop("Function name for symbol-impact mode."),
+                    "endpoint": string_prop("URL path substring for endpoint-impact mode."),
+                    "method": string_prop("Optional HTTP method filter for endpoint mode."),
+                    "depth": int_prop("Max caller/call-chain depth."),
+                    "include_source": bool_prop("Include handler source inline in endpoint mode."),
+                    "scope": string_prop("Optional workspace/package/slice hint, e.g. backend or web.")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::impact(
                     path,
-                    a.str_opt("symbol"),
-                    a.str_opt("endpoint"),
-                    a.str_opt("method"),
-                    a.uint_opt("depth"),
-                    a.bool_opt("include_source"),
-                    a.str_opt("scope"),
+                    args.str_opt("symbol"),
+                    args.str_opt("endpoint"),
+                    args.str_opt("method"),
+                    args.uint_opt("depth"),
+                    args.bool_opt("include_source"),
+                    args.str_opt("scope"),
                 )
-            }),
-        },
-        ToolEntry {
-            schema: schema(
+            },
+        ),
+        tool_entry(
+            schema(
                 "health",
-                d("health"),
+                tool_desc(catalog, "health"),
                 json!({
-                    "path": p(),
-                    "top": i("Max results per category (default 10)"),
-                    "view": s("Response view: compact | full | raw"),
-                    "limit": i("Items per section when view=compact (default 3)"),
-                    "cursor": s("Section cursor in the form <section>:<offset>")
+                    "path": path_prop(),
+                    "top": int_prop("Max results per category (default 10)"),
+                    "view": string_prop("Response view: compact | full | raw"),
+                    "limit": int_prop("Items per section when view=compact (default 3)"),
+                    "cursor": string_prop("Section cursor in the form <section>:<offset>")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::health(
                     path,
-                    a.uint_opt("top"),
-                    a.str_opt("view"),
-                    a.uint_opt("limit"),
-                    a.str_opt("cursor"),
+                    args.uint_opt("top"),
+                    args.str_opt("view"),
+                    args.uint_opt("limit"),
+                    args.str_opt("cursor"),
                 )
-            }),
-        },
-        // ── write ────────────────────────────────────────────────────────────
-        ToolEntry {
-            schema: schema_req(
+            },
+        ),
+    ]
+}
+
+fn write_entries(catalog: &HashMap<&'static str, &'static str>) -> Vec<ToolEntry> {
+    vec![
+        tool_entry(
+            schema_req(
                 "change",
-                d("change"),
+                tool_desc(catalog, "change"),
                 &["action"],
                 json!({
-                    "path": p(),
-                    "action": s("Write action: edit | bulk_edit | rename | move | delete | create | add."),
-                    "name": s("Symbol name for edit/rename/move/delete/add."),
-                    "file": s("File path for edit/create/add."),
-                    "start_line": i("1-based start line for line-range edit."),
-                    "end_line": i("1-based end line for line-range edit."),
-                    "new_content": s("Replacement content for edit."),
-                    "old_string": s("Exact content-match source for edit."),
-                    "new_string": s("Content-match replacement for edit."),
-                    "match_index": i("0-based symbol disambiguation for edit."),
+                    "path": path_prop(),
+                    "action": string_prop("Write action: edit | bulk_edit | rename | move | delete | create | add."),
+                    "name": string_prop("Symbol name for edit/rename/move/delete/add."),
+                    "file": string_prop("File path for edit/create/add."),
+                    "start_line": int_prop("1-based start line for line-range edit."),
+                    "end_line": int_prop("1-based end line for line-range edit."),
+                    "new_content": string_prop("Replacement content for edit."),
+                    "old_string": string_prop("Exact content-match source for edit."),
+                    "new_string": string_prop("Content-match replacement for edit."),
+                    "match_index": int_prop("0-based symbol disambiguation for edit."),
                     "edits": json!({
                         "type": "array",
                         "description": "Edit list for bulk_edit action.",
@@ -506,142 +620,82 @@ fn build_registry() -> Vec<ToolEntry> {
                             }
                         }
                     }),
-                    "new_name": s("Rename target."),
-                    "to_file": s("Destination file for move."),
-                    "force": b("Allow delete even with callers."),
-                    "function_name": s("Function name for create."),
-                    "entity_type": s("Scaffold type for add."),
-                    "after_symbol": s("Insert add scaffold after an existing symbol."),
-                    "language": s("Optional language override for create/add."),
-                    "params": s("Optional typed params JSON for create/add."),
-                    "returns": s("Optional return type for create/add."),
-                    "on": s("Optional receiver/owner type for add.")
+                    "new_name": string_prop("Rename target."),
+                    "to_file": string_prop("Destination file for move."),
+                    "force": bool_prop("Allow delete even with callers."),
+                    "function_name": string_prop("Function name for create."),
+                    "entity_type": string_prop("Scaffold type for add."),
+                    "after_symbol": string_prop("Insert add scaffold after an existing symbol."),
+                    "language": string_prop("Optional language override for create/add."),
+                    "params": string_prop("Optional typed params JSON for create/add."),
+                    "returns": string_prop("Optional return type for create/add."),
+                    "on": string_prop("Optional receiver/owner type for add.")
                 }),
             ),
-            handler: Box::new(|a, path| {
-                let edits = match a.0.get("edits").and_then(|v| v.as_array()) {
-                    Some(items) => {
-                        let mut edits = Vec::new();
-                        for item in items {
-                            let file = item
-                                .get("file")
-                                .and_then(|v| v.as_str())
-                                .ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "Each change.edits item must have a 'file' field"
-                                    )
-                                })?
-                                .to_string();
-                            let byte_start = item
-                                .get("byte_start")
-                                .and_then(|v| v.as_u64())
-                                .ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "Each change.edits item must have a 'byte_start' field"
-                                    )
-                                })? as usize;
-                            let byte_end = item
-                                .get("byte_end")
-                                .and_then(|v| v.as_u64())
-                                .ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "Each change.edits item must have a 'byte_end' field"
-                                    )
-                                })? as usize;
-                            let new_content = item
-                                .get("new_content")
-                                .and_then(|v| v.as_str())
-                                .ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "Each change.edits item must have a 'new_content' field"
-                                    )
-                                })?
-                                .to_string();
-                            edits.push(crate::engine::PatchEdit {
-                                file,
-                                byte_start,
-                                byte_end,
-                                new_content,
-                            });
-                        }
-                        Some(edits)
-                    }
-                    None => None,
-                };
-                crate::engine::change(
-                    path,
-                    a.str_req("action", "change")?,
-                    a.str_opt("name"),
-                    a.str_opt("file"),
-                    a.uint_opt("start_line").map(|v| v as u32),
-                    a.uint_opt("end_line").map(|v| v as u32),
-                    a.str_opt("new_content"),
-                    a.str_opt("old_string"),
-                    a.str_opt("new_string"),
-                    a.uint_opt("match_index"),
-                    edits,
-                    a.str_opt("new_name"),
-                    a.str_opt("to_file"),
-                    a.bool_opt("force"),
-                    a.str_opt("function_name"),
-                    a.str_opt("entity_type"),
-                    a.str_opt("after_symbol"),
-                    a.str_opt("language"),
-                    parse_params(a.0.get("params")),
-                    a.str_opt("returns"),
-                    a.str_opt("on"),
-                )
-            }),
-        },
-        ToolEntry {
-            schema: schema_req(
+            handle_change_tool,
+        ),
+        tool_entry(
+            schema_req(
                 "retry_plan",
-                d("retry_plan"),
+                tool_desc(catalog, "retry_plan"),
                 &["text"],
                 json!({
-                    "path": p(),
-                    "text": s("Failed write output containing a `guard_failure: {...}` line, or a raw guard_failure JSON object."),
-                    "max_retries": i("Maximum retry attempts the caller should allow before stopping (default 2)."),
-                    "context_lines": i("Context lines to include above and below the failing range (default 3).")
+                    "path": path_prop(),
+                    "text": string_prop("Failed write output containing a `guard_failure: {...}` line, or a raw guard_failure JSON object."),
+                    "max_retries": int_prop("Maximum retry attempts the caller should allow before stopping (default 2)."),
+                    "context_lines": int_prop("Context lines to include above and below the failing range (default 3).")
                 }),
             ),
-            handler: Box::new(|a, path| {
+            |args, path| {
                 crate::engine::guard_retry_plan(
                     path,
-                    a.str_req("text", "retry_plan")?,
-                    a.uint_opt("max_retries"),
-                    a.uint_opt("context_lines").map(|v| v as u32),
+                    args.str_req("text", "retry_plan")?,
+                    args.uint_opt("max_retries"),
+                    args.uint_opt("context_lines").map(|value| value as u32),
                 )
-            }),
-        },
-        // ── orchestration ────────────────────────────────────────────────────
-        ToolEntry {
-            schema: schema_req(
-                "script",
-                d("script"),
-                &["code"],
-                json!({
-                    "path": p(),
-                    "code": s("Rhai script to execute. Task-shaped functions: boot(), index(), inspect(#{...}), search(\"...\") or search(#{...}), ask(\"...\") or ask(#{...}), map(\"...\") or map(#{...}), routes(), judge_change(#{...}), impact(#{...}), health() or health(#{...}), change(#{...}), help(\"...\").")
-                }),
-            ),
-            handler: Box::new(|a, path| {
-                crate::engine::run_script(path, a.str_req("code", "script")?)
-            }),
-        },
-        // ── discovery ────────────────────────────────────────────────────────
-        ToolEntry {
-            schema: schema_req(
-                "help",
-                d("help"),
-                &["name"],
-                json!({
-                    "name": s("Tool name to get help for")
-                }),
-            ),
-            handler: Box::new(|a, _path| crate::engine::tool_help(a.str_req("name", "help")?)),
-        },
+            },
+        ),
     ]
+}
+
+fn orchestration_entries(catalog: &HashMap<&'static str, &'static str>) -> Vec<ToolEntry> {
+    vec![tool_entry(
+        schema_req(
+            "script",
+            tool_desc(catalog, "script"),
+            &["code"],
+            json!({
+                "path": path_prop(),
+                "code": string_prop("Rhai script to execute. Task-shaped functions: boot(), index(), inspect(#{...}), search(\"...\") or search(#{...}), ask(\"...\") or ask(#{...}), map(\"...\") or map(#{...}), routes(), judge_change(#{...}), impact(#{...}), health() or health(#{...}), change(#{...}), help(\"...\").")
+            }),
+        ),
+        |args, path| crate::engine::run_script(path, args.str_req("code", "script")?),
+    )]
+}
+
+fn discovery_entries(catalog: &HashMap<&'static str, &'static str>) -> Vec<ToolEntry> {
+    vec![tool_entry(
+        schema_req(
+            "help",
+            tool_desc(catalog, "help"),
+            &["name"],
+            json!({
+                "name": string_prop("Tool name to get help for")
+            }),
+        ),
+        |args, _path| crate::engine::tool_help(args.str_req("name", "help")?),
+    )]
+}
+
+fn build_registry() -> Vec<ToolEntry> {
+    let catalog = tool_catalog_map();
+    let mut registry = Vec::new();
+    registry.extend(bootstrap_entries(&catalog));
+    registry.extend(read_indexed_entries(&catalog));
+    registry.extend(write_entries(&catalog));
+    registry.extend(orchestration_entries(&catalog));
+    registry.extend(discovery_entries(&catalog));
+    registry
 }
 
 static REGISTRY: OnceLock<Vec<ToolEntry>> = OnceLock::new();
@@ -825,6 +879,37 @@ mod tests {
             result.is_err(),
             "should error when pattern is a mode value and query is absent"
         );
+    }
+
+    #[test]
+    fn search_query_and_pattern_defaults_mode_to_all() {
+        let args = Args(json!({
+            "query": "add"
+        }));
+
+        let (query, pattern) = search_query_and_pattern(&args).unwrap();
+
+        assert_eq!(query, "add");
+        assert_eq!(pattern, "all");
+    }
+
+    #[test]
+    fn change_tool_errors_on_missing_bulk_edit_file() {
+        let result = rt().block_on(call_tool(json!({
+            "name": "change",
+            "arguments": {
+                "action": "bulk_edit",
+                "edits": [
+                    {"byte_start": 0, "byte_end": 3, "new_content": "abc"}
+                ]
+            }
+        })));
+
+        assert!(result.is_err(), "malformed edits should be rejected");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Each change.edits item must have a 'file' field"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split `src/mcp.rs` registry construction into grouped builders and named handler helpers
- split `src/engine/script.rs` into engine build, execute, render, and per-tool registration helpers
- split `src/engine/index.rs::llm_workflows` into payload, query, and compact rendering stages

## Verification
- cargo fmt
- cargo test

Refs #178