### PR TITLE
fix: move bake artifacts to .bakes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-03-15
+
+### Changed
+
+- Bake artifacts now live under `.bakes/latest/` instead of `bakes/latest/`.
+- `bake` now adds `.bakes/` to the git exclude file automatically for git repos, including worktree-style `gitdir:` checkouts.
+- yoyo now treats `.bakes/` as managed cache and skips both `.bakes/` and legacy `bakes/` artifact directories during indexing and project snapshots; the user-editable runtime file remains `.yoyo/runtime.json`.
+
 ## [1.13.0] - 2026-03-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "yoyo"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoyo"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Coding agents are strong at local editing and weak at repository truth. They gue
 
 yoyo narrows that gap. It gives the model:
 
-- a grounded repository index in `bakes/latest/bake.db`
+- a grounded repository index in `.bakes/latest/bake.db`
 - a judgment surface before edits
 - a cheaper read surface for signatures and types
 - a structured write path when direct file mutation is the wrong tool
@@ -70,6 +70,8 @@ The point is not to make toy tasks look slightly faster. The point is to make an
 - **Runtime guard**: syntax is not enough for Python, JavaScript, Ruby, PHP, or Clojure. yoyo can also catch "parses fine, crashes on run" failures like missing imports, missing names, and load-time exceptions.
 - **`retry_plan`**: failed guarded writes come back as machine-readable `guard_failure` payloads, then narrow into a bounded inspect-fix-retry workflow instead of vague stderr.
 - **Least-privilege bootstrap**: if `.yoyo/runtime.json` is missing, yoyo now creates a starter config automatically for supported interpreted languages, but keeps runtime execution restricted until the user explicitly widens access.
+
+`.bakes/` is managed cache and is ignored by default in git repos. The file users should actually inspect and edit when widening runtime behavior is `.yoyo/runtime.json`.
 
 Small example: if an edit changes Python `return "hello"` into `return missing_name`, a plain editor saves a broken file. A guarded write rejects it, restores the original file, and returns enough structure for the next repair attempt to target the right lines.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ change  → route write intent                  → write file + reindex
 
 **Read tools run in parallel. Write tools run sequentially.** After every write, the index resyncs automatically so the next read is always fresh.
 
-The index is a SQLite database (`bakes/latest/bake.db`) in your project root. No server, no daemon.
+The index is a SQLite database (`.bakes/latest/bake.db`) in your project root. No server, no daemon.
 
 ---
 
@@ -80,6 +80,7 @@ The important write-side concepts are now:
 - **`guard_failure`** — failed guarded writes return machine-readable failure payloads, not just prose, so the next tool call can reason about `operation`, `phase`, `retryable`, `files_restored`, and the implicated files.
 - **`retry_plan`** — yoyo can turn that failure into a bounded recovery workflow with a targeted `inspect` window and explicit stop conditions.
 - **Least-privilege runtime bootstrap** — if `.yoyo/runtime.json` is missing, yoyo now creates a starter config automatically for supported interpreted languages. The file is intentionally restrictive: file-targeted commands, no inline eval, and `allow_unsandboxed: false` until the user edits it.
+- **Managed bake cache** — `.bakes/` is yoyo-managed cache, not user config. In git repos, yoyo adds `.bakes/` to the repo exclude file automatically. The user-editable file remains `.yoyo/runtime.json`.
 
 Concrete example:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -363,7 +363,7 @@
         <aside class="note">
           <strong>Local by default</strong>
           <p class="muted">
-            The index lives in <code>bakes/latest/bake.db</code>. It is a local SQLite database in the repository.
+            The index lives in <code>.bakes/latest/bake.db</code>. It is a local SQLite database in the repository.
             No hosted service. No hidden agent memory. No outbound API dependency.
           </p>
         </aside>

--- a/src/engine/e2e_tests.rs
+++ b/src/engine/e2e_tests.rs
@@ -958,8 +958,10 @@ function bulkDeleteWorkflowFixture() {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 
         // .git/ blobs must not appear in the file list
-        let bake =
-            crate::engine::db::read_bake_from_db(&root_path.join("bakes/latest/bake.db")).unwrap();
+        let bake = crate::engine::db::read_bake_from_db(
+            &crate::engine::util::bake_artifacts_dir(root_path).join("bake.db"),
+        )
+        .unwrap();
         assert!(
             bake.files
                 .iter()
@@ -1025,6 +1027,47 @@ function bulkDeleteWorkflowFixture() {
                 .map(|a| a.is_empty())
                 .unwrap_or(true),
             "dist/bundle.rs should be excluded via .gitignore"
+        );
+    }
+
+    #[test]
+    fn e2e_bake_uses_dot_bakes_and_git_excludes_it_by_default() {
+        let dir = TempDir::new().unwrap();
+        let root_path = dir.path();
+
+        fs::create_dir_all(root_path.join(".git/info")).unwrap();
+        fs::write(root_path.join("main.rs"), "fn hello() {}\n").unwrap();
+
+        let artifact_dir = root_path.join(".bakes/latest");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        fs::write(
+            artifact_dir.join("ignored.rs"),
+            "fn should_not_index() {}\n",
+        )
+        .unwrap();
+
+        crate::engine::bake(Some(root_path.to_string_lossy().into_owned())).unwrap();
+
+        let exclude = fs::read_to_string(root_path.join(".git/info/exclude")).unwrap();
+        assert!(exclude.contains(".bakes/"));
+        assert!(artifact_dir.join("bake.db").exists());
+
+        let out = crate::engine::symbol(
+            Some(root_path.to_string_lossy().into_owned()),
+            "should_not_index".to_string(),
+            false,
+            None,
+            Some(20),
+            false,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            v["matches"]
+                .as_array()
+                .map(|a| a.is_empty())
+                .unwrap_or(true),
+            ".bakes artifacts must not be indexed"
         );
     }
 
@@ -2071,7 +2114,7 @@ fn get_registry() -> &'static Vec<ToolEntry> {
         // Write a fake embeddings.db so vector_search path is attempted.
         // It will return empty results (no rows), fall through to TF-IDF,
         // but what matters is the note is NOT set when the file exists.
-        let embed_path = dir.path().join("bakes/latest/embeddings.db");
+        let embed_path = crate::engine::util::bake_artifacts_dir(dir.path()).join("embeddings.db");
         // Create an empty-but-valid SQLite DB with the embeddings table.
         {
             let conn = rusqlite::Connection::open(&embed_path).unwrap();
@@ -2097,7 +2140,9 @@ fn get_registry() -> &'static Vec<ToolEntry> {
     fn e2e_semantic_search_note_present_when_embeddings_absent() {
         let dir = setup();
         // Ensure embeddings.db does not exist (bake spawns rebuild in background, may or may not exist)
-        let _ = std::fs::remove_file(dir.path().join("bakes/latest/embeddings.db"));
+        let _ = std::fs::remove_file(
+            crate::engine::util::bake_artifacts_dir(dir.path()).join("embeddings.db"),
+        );
 
         let out =
             crate::engine::semantic_search(root(&dir), "compute sum".into(), None, None, None)
@@ -2121,7 +2166,9 @@ fn get_registry() -> &'static Vec<ToolEntry> {
     #[test]
     fn e2e_semantic_search_tfidf_returns_ranked_results() {
         let dir = setup();
-        let _ = std::fs::remove_file(dir.path().join("bakes/latest/embeddings.db"));
+        let _ = std::fs::remove_file(
+            crate::engine::util::bake_artifacts_dir(dir.path()).join("embeddings.db"),
+        );
 
         let out =
             crate::engine::semantic_search(root(&dir), "add".into(), Some(5), None, None).unwrap();

--- a/src/engine/index.rs
+++ b/src/engine/index.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use anyhow::Result;
 
 use super::types::{
@@ -8,7 +6,10 @@ use super::types::{
     Metapattern, MetapatternStep, ResponseView, ShakePayload, ToolDescription, Workflow,
     WorkflowQueryMatch, WorkflowStep, DEFAULT_COMPACT_LIMIT,
 };
-use super::util::{build_bake_index, load_bake_index, project_snapshot, resolve_project_root};
+use super::util::{
+    build_bake_index, load_bake_index, prepare_bake_artifacts_dir, project_snapshot,
+    resolve_project_root,
+};
 
 /// Public entrypoint for the `llm_instructions` CLI/MCP tool.
 pub fn llm_instructions(path: Option<String>) -> Result<String> {
@@ -1109,7 +1110,7 @@ pub fn shake(path: Option<String>) -> Result<String> {
             project_root: root,
             languages: bake.languages.into_iter().collect(),
             files_indexed: bake.files.len(),
-            notes: "Shake is using the bake index: languages, files, top complex functions, and Express endpoints are derived from bakes/latest/bake.db.".to_string(),
+            notes: "Shake is using the bake index: languages, files, top complex functions, and Express endpoints are derived from .bakes/latest/bake.db.".to_string(),
             top_functions: Some(top_functions),
             express_endpoints: Some(express_endpoints),
         };
@@ -1139,10 +1140,10 @@ pub fn shake(path: Option<String>) -> Result<String> {
 /// Public entrypoint for the `bake` tool: build and persist a basic project index.
 ///
 /// This first version records files, languages, and sizes, and writes
-/// `bakes/latest/bake.db` under the project root.
+/// `.bakes/latest/bake.db` under the project root.
 pub fn bake(path: Option<String>) -> Result<String> {
     let root = resolve_project_root(path)?;
-    let bakes_dir = root.join("bakes").join("latest");
+    let bakes_dir = prepare_bake_artifacts_dir(&root)?;
     let bake_path = bakes_dir.join("bake.db");
 
     // Load fingerprints from existing DB for incremental mode.
@@ -1155,10 +1156,6 @@ pub fn bake(path: Option<String>) -> Result<String> {
     let is_incremental = !fingerprints.is_empty();
 
     let (bake, removed, skipped) = build_bake_index(&root, &fingerprints)?;
-
-    fs::create_dir_all(&bakes_dir).map_err(|e| {
-        anyhow::anyhow!("Failed to create bakes dir: {}: {}", bakes_dir.display(), e)
-    })?;
 
     let (total_files, all_languages) = if is_incremental {
         crate::engine::db::write_bake_incremental(&bake, &removed, &bake_path).map_err(|e| {

--- a/src/engine/judge.rs
+++ b/src/engine/judge.rs
@@ -9,7 +9,7 @@ use super::types::{
     JudgeOwnershipLayer, JudgeRejectedAlternative,
 };
 use super::util::{
-    backend_scope_boost, bake_scope_dependencies, bake_scopes, effective_scope,
+    backend_scope_boost, bake_artifacts_dir, bake_scope_dependencies, bake_scopes, effective_scope,
     matches_scope_filter, require_bake_index, resolve_project_root, scope_hints,
 };
 
@@ -271,7 +271,7 @@ fn semantic_candidates<'a>(
     scope_filter: Option<&str>,
     limit: usize,
 ) -> Vec<(f32, &'a crate::lang::IndexedFunction)> {
-    let bake_dir = root.join("bakes").join("latest");
+    let bake_dir = bake_artifacts_dir(&root);
     if let Ok(Some(matches)) =
         crate::engine::embed::vector_search(&bake_dir, query, limit, file_filter)
     {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -8,7 +8,7 @@ use super::types::{
     TypeMethodSummary,
 };
 use super::util::{
-    backend_scope_boost, bake_scope_dependencies, bake_scopes, effective_scope,
+    backend_scope_boost, bake_artifacts_dir, bake_scope_dependencies, bake_scopes, effective_scope,
     matches_scope_filter, require_bake_index, resolve_project_root, scope_hints,
 };
 
@@ -1248,7 +1248,7 @@ mod semantic_note_tests {
     use crate::engine::types::BakeIndex;
 
     fn write_minimal_bake(dir: &TempDir) {
-        let bakes_dir = dir.path().join("bakes/latest");
+        let bakes_dir = crate::engine::util::bake_artifacts_dir(dir.path());
         std::fs::create_dir_all(&bakes_dir).unwrap();
         let bake = BakeIndex {
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -1307,7 +1307,9 @@ mod semantic_note_tests {
         // Write a real bake so there are functions to TF-IDF over.
         crate::engine::bake(Some(dir.path().to_string_lossy().into_owned())).unwrap();
         // Delete embeddings.db if it exists (bake spawns it in background).
-        let _ = std::fs::remove_file(dir.path().join("bakes/latest/embeddings.db"));
+        let _ = std::fs::remove_file(
+            crate::engine::util::bake_artifacts_dir(dir.path()).join("embeddings.db"),
+        );
 
         let out = crate::engine::semantic_search(
             Some(dir.path().to_string_lossy().into_owned()),
@@ -1667,7 +1669,7 @@ mod semantic_note_tests {
 }
 
 /// Public entrypoint for the `semantic_search` tool.
-/// Uses embedding-backed cosine similarity when `bakes/latest/embeddings.db` exists
+/// Uses embedding-backed cosine similarity when `.bakes/latest/embeddings.db` exists
 /// (built by `bake` via fastembed + SQLite). Falls back to TF-IDF otherwise.
 pub fn semantic_search(
     path: Option<String>,
@@ -1679,7 +1681,7 @@ pub fn semantic_search(
     let root = resolve_project_root(path)?;
     let limit = limit.unwrap_or(10).min(50);
     let file_filter = file.as_deref().map(str::to_lowercase);
-    let bake_dir = root.join("bakes").join("latest");
+    let bake_dir = bake_artifacts_dir(&root);
     let bake = require_bake_index(&root)?;
     let scope_used = effective_scope(
         &bake.files,

--- a/src/engine/util.rs
+++ b/src/engine/util.rs
@@ -20,6 +20,9 @@ pub(crate) struct ScopeProfile {
     pub(crate) tags: BTreeSet<String>,
 }
 
+const BAKE_DIRNAME: &str = ".bakes";
+const LEGACY_BAKE_DIRNAME: &str = "bakes";
+
 fn requested_root(path: Option<String>) -> Result<PathBuf> {
     if let Some(p) = path {
         let pb = PathBuf::from(p);
@@ -35,14 +38,118 @@ fn requested_root(path: Option<String>) -> Result<PathBuf> {
     Ok(cwd)
 }
 
+pub(crate) fn bake_artifacts_dir(root: &Path) -> PathBuf {
+    root.join(BAKE_DIRNAME).join("latest")
+}
+
+fn legacy_bake_artifacts_dir(root: &Path) -> PathBuf {
+    root.join(LEGACY_BAKE_DIRNAME).join("latest")
+}
+
 fn bake_index_path(root: &Path) -> PathBuf {
-    root.join("bakes").join("latest").join("bake.db")
+    bake_artifacts_dir(root).join("bake.db")
+}
+
+fn legacy_bake_index_path(root: &Path) -> PathBuf {
+    legacy_bake_artifacts_dir(root).join("bake.db")
+}
+
+fn existing_bake_index_path(root: &Path) -> Option<PathBuf> {
+    let bake_path = bake_index_path(root);
+    if bake_path.exists() {
+        return Some(bake_path);
+    }
+
+    let legacy_path = legacy_bake_index_path(root);
+    legacy_path.exists().then_some(legacy_path)
+}
+
+fn is_bake_artifact_dir_name(name: &str) -> bool {
+    matches!(name, BAKE_DIRNAME | LEGACY_BAKE_DIRNAME)
+}
+
+fn git_dir(root: &Path) -> Result<Option<PathBuf>> {
+    let git_path = root.join(".git");
+    let Ok(meta) = fs::metadata(&git_path) else {
+        return Ok(None);
+    };
+
+    if meta.is_dir() {
+        return Ok(Some(git_path));
+    }
+
+    if meta.is_file() {
+        let content = fs::read_to_string(&git_path)
+            .with_context(|| format!("Failed to read {}", git_path.display()))?;
+        let Some(raw) = content.strip_prefix("gitdir:") else {
+            return Ok(None);
+        };
+        let git_dir = PathBuf::from(raw.trim());
+        let resolved = if git_dir.is_absolute() {
+            git_dir
+        } else {
+            root.join(git_dir)
+        };
+        return Ok(Some(resolved));
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn ensure_bake_gitignored(root: &Path) -> Result<()> {
+    let Some(git_dir) = git_dir(root)? else {
+        return Ok(());
+    };
+
+    let info_dir = git_dir.join("info");
+    fs::create_dir_all(&info_dir)
+        .with_context(|| format!("Failed to create {}", info_dir.display()))?;
+    let exclude_path = info_dir.join("exclude");
+    let mut exclude = if exclude_path.exists() {
+        fs::read_to_string(&exclude_path)
+            .with_context(|| format!("Failed to read {}", exclude_path.display()))?
+    } else {
+        String::new()
+    };
+
+    if exclude.lines().any(|line| line.trim() == ".bakes/") {
+        return Ok(());
+    }
+
+    if !exclude.is_empty() && !exclude.ends_with('\n') {
+        exclude.push('\n');
+    }
+    exclude.push_str(".bakes/\n");
+    fs::write(&exclude_path, exclude)
+        .with_context(|| format!("Failed to write {}", exclude_path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn prepare_bake_artifacts_dir(root: &Path) -> Result<PathBuf> {
+    let legacy_root = root.join(LEGACY_BAKE_DIRNAME);
+    let current_root = root.join(BAKE_DIRNAME);
+    if legacy_root.exists() && !current_root.exists() {
+        fs::rename(&legacy_root, &current_root).with_context(|| {
+            format!(
+                "Failed to move legacy bake dir from {} to {}",
+                legacy_root.display(),
+                current_root.display()
+            )
+        })?;
+    }
+
+    ensure_bake_gitignored(root)?;
+
+    let bake_dir = bake_artifacts_dir(root);
+    fs::create_dir_all(&bake_dir)
+        .with_context(|| format!("Failed to create {}", bake_dir.display()))?;
+    Ok(bake_dir)
 }
 
 fn find_bake_root(start: &Path) -> Option<PathBuf> {
     start
         .ancestors()
-        .find(|ancestor| bake_index_path(ancestor).exists())
+        .find(|ancestor| existing_bake_index_path(ancestor).is_some())
         .map(Path::to_path_buf)
 }
 
@@ -66,14 +173,14 @@ fn find_project_root_hint(start: &Path) -> Option<PathBuf> {
 fn missing_bake_error(root: &Path) -> anyhow::Error {
     if let Some(project_root) = find_project_root_hint(root) {
         return anyhow!(
-            "No bake index found under {}. Did you mean to pass the project root {}? Run `bake` there first to build bakes/latest/bake.db.",
+            "No bake index found under {}. Did you mean to pass the project root {}? Run `bake` there first to build .bakes/latest/bake.db.",
             root.display(),
             project_root.display()
         );
     }
 
     anyhow!(
-        "No bake index found under {}. Run `bake` first to build bakes/latest/bake.db.",
+        "No bake index found under {}. Run `bake` first to build .bakes/latest/bake.db.",
         root.display()
     )
 }
@@ -408,7 +515,7 @@ fn refresh_scoped_paths(
     bake: &BakeIndex,
     touched_files: &[String],
 ) -> Result<BakeIndex> {
-    let bake_path = bake_index_path(root);
+    let bake_path = existing_bake_index_path(root).unwrap_or_else(|| bake_index_path(root));
     let affected = expand_to_scope_files(bake, touched_files);
     let mut fingerprints = fingerprints_from_bake(bake);
     for path in &affected {
@@ -490,6 +597,9 @@ pub(crate) fn project_snapshot(root: &PathBuf) -> Result<Snapshot> {
             if path.is_dir() {
                 // Skip common heavy/irrelevant directories for a quick snapshot.
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if is_bake_artifact_dir_name(name) {
+                        continue;
+                    }
                     if matches!(
                         name,
                         ".git" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
@@ -515,6 +625,9 @@ pub(crate) fn project_snapshot(root: &PathBuf) -> Result<Snapshot> {
             let path = entry.path();
             if path.is_dir() {
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if is_bake_artifact_dir_name(name) {
+                        continue;
+                    }
                     if matches!(
                         name,
                         ".git" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
@@ -556,10 +669,9 @@ pub(crate) fn project_snapshot(root: &PathBuf) -> Result<Snapshot> {
 }
 
 pub(crate) fn load_bake_index(root: &PathBuf) -> Result<Option<BakeIndex>> {
-    let bake_path = bake_index_path(root);
-    if !bake_path.exists() {
+    let Some(bake_path) = existing_bake_index_path(root) else {
         return Ok(None);
-    }
+    };
 
     let bake = super::db::read_bake_from_db(&bake_path)
         .with_context(|| format!("Failed to read bake index from {}", bake_path.display()))?;
@@ -586,12 +698,12 @@ pub(crate) fn load_bake_index(root: &PathBuf) -> Result<Option<BakeIndex>> {
 
     if version_stale {
         let (fresh, _, _) = build_bake_index(root, &std::collections::HashMap::new())?;
-        let bakes_dir = root.join("bakes").join("latest");
-        fs::create_dir_all(&bakes_dir)?;
-        super::db::write_bake_to_db(&fresh, &bake_path).with_context(|| {
+        prepare_bake_artifacts_dir(root)?;
+        let fresh_path = bake_index_path(root);
+        super::db::write_bake_to_db(&fresh, &fresh_path).with_context(|| {
             format!(
                 "Failed to write refreshed bake index to {}",
-                bake_path.display()
+                fresh_path.display()
             )
         })?;
         return Ok(Some(fresh));
@@ -723,7 +835,11 @@ pub(crate) fn build_bake_index(
         .hidden(false) // don't skip hidden files — .gitignore handles exclusions
         .git_ignore(true) // respect .gitignore (nested, global, .git/info/exclude)
         .require_git(false) // apply .gitignore rules even outside a git repo
-        .filter_entry(|e| e.file_name() != ".git") // never descend into .git/
+        .filter_entry(|e| {
+            e.file_name() != ".git"
+                && e.file_name() != BAKE_DIRNAME
+                && e.file_name() != LEGACY_BAKE_DIRNAME
+        }) // never descend into repo metadata or bake artifacts
         .build()
     {
         let entry = match result {
@@ -918,7 +1034,7 @@ mod tests {
     use crate::engine::types::BakeIndex;
 
     fn write_bake(root: &TempDir) {
-        let bakes_dir = root.path().join("bakes/latest");
+        let bakes_dir = bake_artifacts_dir(root.path());
         fs::create_dir_all(&bakes_dir).unwrap();
         let bake = BakeIndex {
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -933,6 +1049,39 @@ mod tests {
             impls: vec![],
         };
         crate::engine::db::write_bake_to_db(&bake, &bakes_dir.join("bake.db")).unwrap();
+    }
+
+    #[test]
+    fn ensure_bake_gitignored_writes_info_exclude() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".git/info")).unwrap();
+
+        ensure_bake_gitignored(dir.path()).unwrap();
+        let exclude = fs::read_to_string(dir.path().join(".git/info/exclude")).unwrap();
+        assert!(exclude.contains(".bakes/"));
+
+        ensure_bake_gitignored(dir.path()).unwrap();
+        let exclude = fs::read_to_string(dir.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(
+            exclude
+                .lines()
+                .filter(|line| line.trim() == ".bakes/")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn ensure_bake_gitignored_supports_gitdir_file() {
+        let dir = TempDir::new().unwrap();
+        let git_dir = dir.path().join(".git-worktree");
+        fs::create_dir_all(git_dir.join("info")).unwrap();
+        fs::write(dir.path().join(".git"), "gitdir: .git-worktree\n").unwrap();
+
+        ensure_bake_gitignored(dir.path()).unwrap();
+
+        let exclude = fs::read_to_string(git_dir.join("info/exclude")).unwrap();
+        assert!(exclude.contains(".bakes/"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move bake artifacts from `bakes/latest/` to `.bakes/latest/`
- add `.bakes/` to the git exclude file automatically for git repos, including worktree `gitdir:` layouts
- skip `.bakes/` and legacy `bakes/` artifact directories during indexing and snapshots
- document that `.bakes/` is managed cache while `.yoyo/runtime.json` remains the user-editable runtime file
- bump release version to `1.13.1`

## Verification
- `cargo fmt`
- `cargo test`
- `cargo build --release`
- `codesign --force --deep --sign - target/release/yoyo`

Closes #182