### PR TITLE
docs: make yoyo positioning agent-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Shoutout to **[xagi.in](https://xagi.in/)**, the first sponsor of yoyo.
 
-yoyo is a local MCP server for repository reading and change work. It exists to make coding agents less hallucinated, more grounded, and more truthful when they answer questions about a real codebase.
+yoyo is a local MCP server for repository reading and change work. It is built for agents first, so they stay grounded in the repo instead of guessing from model memory.
 
 The core product is not generic search. It is a smaller and more reliable interface to the repository:
 
@@ -55,7 +55,7 @@ See [`evals/README.md`](./evals/README.md) for the current eval direction.
 
 Coding agents are strong at local editing and weak at repository truth. They guess ownership layers, invent file paths, over-read source files, and lose the actual invariants of the system.
 
-yoyo narrows that gap. It gives the model:
+yoyo narrows that gap. It gives the agent:
 
 - a grounded repository index in `.bakes/latest/bake.db`
 - a judgment surface before edits
@@ -69,9 +69,9 @@ The point is not to make toy tasks look slightly faster. The point is to make an
 - **Guarded write**: yoyo writes the candidate edit, runs the relevant checks, and restores the original file if the edit fails those checks.
 - **Runtime guard**: syntax is not enough for Python, JavaScript, Ruby, PHP, or Clojure. yoyo can also catch "parses fine, crashes on run" failures like missing imports, missing names, and load-time exceptions.
 - **`retry_plan`**: failed guarded writes come back as machine-readable `guard_failure` payloads, then narrow into a bounded inspect-fix-retry workflow instead of vague stderr.
-- **Least-privilege bootstrap**: if `yoyo.json` is missing, yoyo now creates a starter config automatically for supported interpreted languages, but keeps runtime execution restricted until an agent explicitly widens access.
+- **Least-privilege bootstrap**: if `yoyo.json` is missing, yoyo now creates it automatically for supported interpreted languages, but keeps runtime execution restricted until an agent updates the repo policy.
 
-`boot` now surfaces agent-managed config, managed paths, a concrete runtime-access example, and project conventions loaded from `yoyo.json`. That same file is where agents can store repo styling, frameworks, and common commands so the context does not need to be re-prompted. `.bakes/` is managed cache and is ignored by default in git repos.
+`boot` now surfaces agent-managed config, managed paths, a concrete runtime-access example, and project conventions loaded from `yoyo.json`. That file is the repo contract for agents: style rules, frameworks, common commands, and runtime policy all live there so the same context does not need to be re-prompted every session. `.bakes/` is managed cache and is ignored by default in git repos.
 
 Small example: if an edit changes Python `return "hello"` into `return missing_name`, a plain editor saves a broken file. A guarded write rejects it, restores the original file, and returns enough structure for the next repair attempt to target the right lines.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # yoyo — full documentation
 
-yoyo parses your codebase and gives Claude Code, Cursor, Codex CLI, Gemini CLI, or OpenCode a curated task-shaped MCP surface for reading and editing code. Every answer comes from the AST, not model memory. The product goal is more truthful, more grounded codebase answers with less hallucination. No API keys, no SaaS, no telemetry.
+yoyo parses your codebase and gives Claude Code, Cursor, Codex CLI, Gemini CLI, or OpenCode a curated task-shaped MCP surface for reading and editing code. It is built for agents first. Every answer should come from the repo and AST, not model memory. No API keys, no SaaS, no telemetry.
 
 Essays:
 
@@ -79,8 +79,8 @@ The important write-side concepts are now:
 - **Runtime guard** — this is the post-write check for interpreted languages where parsing is not enough. It catches failures like Python `NameError`, JavaScript module-load errors, and Clojure namespace/load-time failures.
 - **`guard_failure`** — failed guarded writes return machine-readable failure payloads, not just prose, so the next tool call can reason about `operation`, `phase`, `retryable`, `files_restored`, and the implicated files.
 - **`retry_plan`** — yoyo can turn that failure into a bounded recovery workflow with a targeted `inspect` window and explicit stop conditions.
-- **Least-privilege runtime bootstrap** — if `yoyo.json` is missing, yoyo now creates a starter config automatically for supported interpreted languages. The file is intentionally restrictive: file-targeted commands, no inline eval, and `allow_unsandboxed: false` until an agent updates it.
-- **Managed bake cache** — `.bakes/` is yoyo-managed cache, not user config. In git repos, yoyo adds `.bakes/` to the repo exclude file automatically. The repo-level agent contract is `yoyo.json`: runtime policy plus project styling, frameworks, and common commands.
+- **Least-privilege runtime bootstrap** — if `yoyo.json` is missing, yoyo now creates it automatically for supported interpreted languages. The file is intentionally restrictive: file-targeted commands, no inline eval, and `allow_unsandboxed: false` until an agent updates the policy.
+- **Managed bake cache** — `.bakes/` is yoyo-managed cache, not repo config. In git repos, yoyo adds `.bakes/` to the repo exclude file automatically. The repo-level agent contract is `yoyo.json`: project styling, frameworks, common commands, and runtime policy in one file.
 
 Concrete example:
 
@@ -106,7 +106,7 @@ Each agent session follows this sequence:
 5. **Write** — `change` is the MCP write verb and the error-bounded write surface. It routes to the underlying write mechanisms and auto-reindexes. The agent does not edit files directly when a yoyo write tool applies.
 6. **Discover** — `help` returns params, output shape, example, and limitations for any tool on demand. No need to memorize schemas.
 
-Result: agents answer from facts, not memory. More grounded. Less hallucinated. No stale function names.
+Result: agents start with repo context already loaded, answer from facts instead of memory, and stop asking for the same style or framework instructions every session.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,8 +295,8 @@
       <div class="eyebrow">Grounded codebase work</div>
       <h1>Your agent should read the code that is there, not the code it imagines.</h1>
       <p class="lead">
-        yoyo is a local MCP server for codebase reading and change work. It exists to make coding agents
-        less hallucinated, more grounded, and more truthful when they answer questions about a real repository.
+        yoyo is a local MCP server for codebase reading and change work. It is built for agents first,
+        so they start from repo truth instead of model memory.
       </p>
       <p class="lead">
         The core product is not a bag of search tricks. It is a smaller and more reliable interface to the codebase:
@@ -346,7 +346,7 @@
             for toy projects and dangerous for real ones.
           </p>
           <p>
-            yoyo narrows that gap. It gives the model a grounded index, a judgment surface before edits, a cheaper
+            yoyo narrows that gap. It gives the agent a grounded index, a judgment surface before edits, a cheaper
             read surface for signatures and types, and a structured write path when a direct file mutation is the wrong tool.
           </p>
           <div class="tool-line">
@@ -416,14 +416,12 @@
         </div>
 
         <aside class="note">
-          <strong>Least-privilege by default</strong>
+          <strong>Agent-first config</strong>
           <p class="muted">
-            If <code>yoyo.json</code> is missing, yoyo now creates a starter config automatically for
-            supported interpreted languages. The file is still restrictive: file-targeted commands only,
-            no inline eval, and runtime execution remains disabled until an agent widens access explicitly. The
-            <code>boot</code> payload also points to <code>yoyo.json</code> as the agent-managed, git-trackable config,
-            loads repo conventions from it, shows a concrete example for enabling unsandboxed file-targeted runtime checks, and keeps
-            <code>.bakes/</code> separate as managed cache.
+            If <code>yoyo.json</code> is missing, yoyo now creates it automatically for supported interpreted
+            languages. Agents keep repo rules, common commands, and runtime policy in that tracked file instead
+            of asking for the same context again and again. <code>boot</code> points to that file directly and
+            keeps <code>.bakes/</code> separate as managed cache.
           </p>
         </aside>
       </div>

--- a/docs/rlm-and-yoyo.html
+++ b/docs/rlm-and-yoyo.html
@@ -309,7 +309,7 @@
           So the lesson is not “turn <code>yoyo</code> into a Python REPL.” The lesson is “keep moving toward repo-as-environment, but keep the interface opinionated and safe.”
         </p>
         <p>
-          That is also why the current runtime bootstrap matters. <code>yoyo</code> can now create <code>yoyo.json</code> automatically for supported interpreted languages, but it does so with least-privilege defaults. The setup is automated; the permission grant is not. That is the right difference between a software engineering environment and a general-purpose free-form REPL.
+          That is also why the current runtime bootstrap matters. <code>yoyo</code> can now create <code>yoyo.json</code> automatically for supported interpreted languages, but it does so with least-privilege defaults. The setup is automated for the agent; broader runtime access still has to be made explicit in repo policy. That is the right difference between a software engineering environment and a general-purpose free-form REPL.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- update README and website copy to say yoyo is built for agents first
- describe  as the repo contract agents use to carry repo rules forward
- remove human-first wording around runtime policy and repeated prompting

## Testing
- not run; docs-only change
