### PR TITLE
fix: add Intel Mac (x86_64-apple-darwin) Homebrew support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,19 +100,22 @@ jobs:
       - name: Compute SHA256 for macOS ARM tarball
         id: sha_macos_arm
         run: |
-          sha=$(curl -sL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-aarch64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
+          set -o pipefail
+          sha=$(curl -fSL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-aarch64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Compute SHA256 for macOS Intel tarball
         id: sha_macos_intel
         run: |
-          sha=$(curl -sL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-x86_64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
+          set -o pipefail
+          sha=$(curl -fSL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-x86_64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Compute SHA256 for Linux tarball
         id: sha_linux
         run: |
-          sha=$(curl -sL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-x86_64-unknown-linux-gnu.tar.gz | shasum -a 256 | awk '{print $1}')
+          set -o pipefail
+          sha=$(curl -fSL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-x86_64-unknown-linux-gnu.tar.gz | shasum -a 256 | awk '{print $1}')
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Checkout homebrew-yoyo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
             target: aarch64-apple-darwin
             binary: yoyo
             archive: yoyo-aarch64-apple-darwin.tar.gz
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: yoyo
+            archive: yoyo-x86_64-apple-darwin.tar.gz
 
     steps:
       - name: Checkout repository
@@ -93,10 +97,16 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
-      - name: Compute SHA256 for macOS tarball
-        id: sha_macos
+      - name: Compute SHA256 for macOS ARM tarball
+        id: sha_macos_arm
         run: |
           sha=$(curl -sL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-aarch64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+
+      - name: Compute SHA256 for macOS Intel tarball
+        id: sha_macos_intel
+        run: |
+          sha=$(curl -sL https://github.com/avirajkhare00/yoyo/releases/download/${{ github.ref_name }}/yoyo-x86_64-apple-darwin.tar.gz | shasum -a 256 | awk '{print $1}')
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Compute SHA256 for Linux tarball
@@ -115,9 +125,10 @@ jobs:
       - name: Update formula
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          SHA_MACOS="${{ steps.sha_macos.outputs.sha }}"
+          SHA_MACOS_ARM="${{ steps.sha_macos_arm.outputs.sha }}"
+          SHA_MACOS_INTEL="${{ steps.sha_macos_intel.outputs.sha }}"
           SHA_LINUX="${{ steps.sha_linux.outputs.sha }}"
-          export VERSION SHA_MACOS SHA_LINUX
+          export VERSION SHA_MACOS_ARM SHA_MACOS_INTEL SHA_LINUX
           python3 - <<'PY'
           import os
           from pathlib import Path
@@ -125,7 +136,8 @@ jobs:
           template = Path("source/packaging/homebrew/yoyo.rb.template").read_text()
           rendered = (
               template.replace("__VERSION__", os.environ["VERSION"])
-              .replace("__SHA_MACOS__", os.environ["SHA_MACOS"])
+              .replace("__SHA_MACOS_ARM__", os.environ["SHA_MACOS_ARM"])
+              .replace("__SHA_MACOS_INTEL__", os.environ["SHA_MACOS_INTEL"])
               .replace("__SHA_LINUX__", os.environ["SHA_LINUX"])
           )
           Path("homebrew-yoyo/Formula/yoyo.rb").write_text(rendered)

--- a/packaging/homebrew/yoyo.rb.template
+++ b/packaging/homebrew/yoyo.rb.template
@@ -7,7 +7,10 @@ class Yoyo < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/avirajkhare00/yoyo/releases/download/v#{version}/yoyo-aarch64-apple-darwin.tar.gz"
-      sha256 "__SHA_MACOS__"
+      sha256 "__SHA_MACOS_ARM__"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/avirajkhare00/yoyo/releases/download/v#{version}/yoyo-x86_64-apple-darwin.tar.gz"
+      sha256 "__SHA_MACOS_INTEL__"
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #144 — `brew install yoyo` fails on Intel Macs with "formula requires at least a URL".

**Root cause:** The Homebrew formula only defines URLs for macOS ARM (`Hardware::CPU.arm?`) and Linux Intel. On Intel Macs, `on_macos` matches but no CPU branch applies, leaving `url` unset.

**Changes:**

- Add `x86_64-apple-darwin` to the release build matrix (cross-compiled on `macos-latest`)
- Add SHA256 computation step for the new Intel Mac tarball
- Extend `yoyo.rb.template` with `elsif Hardware::CPU.intel?` under `on_macos`
- Rename `__SHA_MACOS__` → `__SHA_MACOS_ARM__` for clarity (avoids ambiguity now that there are two macOS targets)

## Files changed

- `.github/workflows/release.yml` — build matrix + SHA + template rendering
- `packaging/homebrew/yoyo.rb.template` — Intel Mac branch

## Test plan

- [ ] Verify `x86_64-apple-darwin` builds on `macos-latest` (ARM runners support x86_64 cross-compilation via Rust target)
- [ ] Confirm the Homebrew formula renders correctly with three SHA placeholders
- [ ] Test `brew install` on an Intel Mac (or Rosetta environment)